### PR TITLE
Iss1828 - Add GitHub workflows as overlays for the mono repo and adjust script

### DIFF
--- a/overlays/.github/workflows/buildutils.yaml
+++ b/overlays/.github/workflows/buildutils.yaml
@@ -53,10 +53,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          # username: galasa-team
-          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: galasa-team
+          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
       
       - name: Extract metadata for galasabld image
         id: metadata
@@ -109,10 +107,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          # username: galasa-team
-          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: galasa-team
+          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
       
       - name: Extract metadata for galasabld-ibm image
         id: metadata
@@ -170,10 +166,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          # username: galasa-team
-          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: galasa-team
+          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
       
       - name: Extract metadata for openapi2beans image
         id: metadata
@@ -240,10 +234,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          # username: galasa-team
-          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: galasa-team
+          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
       
       - name: Extract metadata for buildutils-executables image
         id: metadata
@@ -260,15 +252,15 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
 
-  # report-failure:
-  #   name: Report failure in workflow
-  #   runs-on: ubuntu-latest
-  #   needs: [build-push-galasabld, build-push-galasabld-ibm, build-push-openapi2beans, build-push-buildutils-executables]
-  #   if: failure()
+  report-failure:
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [build-push-galasabld, build-push-galasabld-ibm, build-push-openapi2beans, build-push-buildutils-executables]
+    if: failure()
 
-  #   steps:
-  #     - name: Report failure in workflow to Slack
-  #       env: 
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #       run : |
-  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "buildutils" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+    steps:
+      - name: Report failure in workflow to Slack
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run : |
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "buildutils" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/buildutils.yaml
+++ b/overlays/.github/workflows/buildutils.yaml
@@ -1,0 +1,274 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Buildutils Main Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  NAMESPACE: ${{ github.repository_owner }}
+  BRANCH: ${{ github.ref_name }}
+
+jobs:
+
+  log-unchanged:
+    name: Buildutils is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The buildutils module is unchanged"
+
+  build-push-galasabld:
+    name: Build and push galasabld artifacts
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup up Go
+        uses: actions/setup-go@v5
+        with: 
+          go-version: 1.22
+      
+      - name: Build galasabld using the Makefile
+        working-directory: modules/buildutils
+        run: |
+          make all 
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          # username: galasa-team
+          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      
+      - name: Extract metadata for galasabld image
+        id: metadata
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasabld-amd64
+        
+      - name: Build galasabld image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/buildutils
+          file: modules/buildutils/dockerfiles/galasabld/dockerfile.galasabld
+          load: true
+          tags: galasabld-amd64:${{ env.BRANCH }}
+          build-args: |
+            platform=linux-amd64
+        
+      - name: Test galasabld image
+        run: |
+          docker run --rm galasabld-amd64:${{ env.BRANCH }}
+        
+      - name: Build and push galasabld image
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/buildutils
+          file: modules/buildutils/dockerfiles/galasabld/dockerfile.galasabld
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            platform=linux-amd64
+        
+      - name: Upload galasabld executables
+        uses: actions/upload-artifact@v4
+        with:
+          name: galasabld
+          path: modules/buildutils/bin
+
+  build-push-galasabld-ibm:
+    name: Build and push galasabld-ibm artefact
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    needs: [build-push-galasabld]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          # username: galasa-team
+          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      
+      - name: Extract metadata for galasabld-ibm image
+        id: metadata
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasabld-ibm
+        
+      - name: Build galasabld-ibm image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/buildutils
+          file: modules/buildutils/dockerfiles/galasabld/dockerfile.galasabld-ibm
+          load: true
+          tags: galasabld-ibm:${{ env.BRANCH }}
+          build-args: |
+            dockerRepository=ghcr.io
+            branch=${{ env.BRANCH }}
+        
+      - name: Test galasabld-ibm image
+        run: |
+          docker run --rm galasabld-ibm:${{ env.BRANCH }}
+        
+      - name: Build and push galasabld-ibm image
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/buildutils
+          file: modules/buildutils/dockerfiles/galasabld/dockerfile.galasabld-ibm
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            dockerRepository=ghcr.io
+            branch=${{ env.BRANCH }}
+
+  build-push-openapi2beans:
+    name: Build and push openapi2beans artifacts
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup up Go
+        uses: actions/setup-go@v5
+        with: 
+          go-version: 1.22
+      
+      - name: Build openapi2beans using the Makefile
+        working-directory: modules/buildutils
+        run: |
+          make all -C openapi2beans
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          # username: galasa-team
+          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      
+      - name: Extract metadata for openapi2beans image
+        id: metadata
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/openapi2beans
+        
+      - name: Build openapi2beans image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/buildutils
+          file: modules/buildutils/dockerfiles/openapi2beans/dockerfile.openapi2beans
+          load: true
+          tags: openapi2beans:${{ env.BRANCH }}
+          build-args: |
+            platform=linux-x86_64
+        
+      - name: Test openapi2beans image
+        run: |
+          docker run --rm openapi2beans:${{ env.BRANCH }}
+        
+      - name: Build and push openapi2beans image
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/buildutils
+          file: modules/buildutils/dockerfiles/openapi2beans/dockerfile.openapi2beans
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            platform=linux-x86_64 
+              
+      - name: Upload openapi2beans executables
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi2beans
+          path: modules/buildutils/openapi2beans/bin
+
+  build-push-buildutils-executables:
+    name: Build and push buildutils repository executables
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup up Go
+        uses: actions/setup-go@v5
+        with: 
+          go-version: 1.22
+          
+      - name: Build galasabld using the Makefile
+        working-directory: modules/buildutils
+        run: |
+          make all 
+
+      - name: Build openapi2beans using the Makefile
+        working-directory: modules/buildutils
+        run: |
+          make all -C openapi2beans
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          # username: galasa-team
+          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      
+      - name: Extract metadata for buildutils-executables image
+        id: metadata
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/buildutils-executables
+        
+      - name: Build and push buildutils-executables image
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/buildutils
+          file: modules/buildutils/dockerfiles/dockerfile.buildutils
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+
+  # report-failure:
+  #   name: Report failure in workflow
+  #   runs-on: ubuntu-latest
+  #   needs: [build-push-galasabld, build-push-galasabld-ibm, build-push-openapi2beans, build-push-buildutils-executables]
+  #   if: failure()
+
+  #   steps:
+  #     - name: Report failure in workflow to Slack
+  #       env: 
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #       run : |
+  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "buildutils" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/buildutils.yaml
+++ b/overlays/.github/workflows/buildutils.yaml
@@ -252,6 +252,18 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
 
+      - name: Recycle application in ArgoCD
+        env: 
+            ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-bld restart --kind Deployment --resource-name bld-${{ env.BRANCH }} --server argocd.galasa.dev
+
+      - name: Wait for app health in ArgoCD
+        env: 
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-bld --resource apps:Deployment:bld-${{ env.BRANCH }} --health --server argocd.galasa.dev
+
   report-failure:
     name: Report failure in workflow
     runs-on: ubuntu-latest

--- a/overlays/.github/workflows/extensions.yaml
+++ b/overlays/.github/workflows/extensions.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/wrapping/dev/galasa
+          path: modules/artifacts
 
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -101,7 +101,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -109,7 +109,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download framework artifacts from this workflow
         id: download-framework
@@ -117,7 +117,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this push,
       # download artifacts from the last successful workflow.
@@ -127,7 +127,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.wrapping-artifact-id }}
 
@@ -136,7 +136,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -145,7 +145,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.maven-artifact-id }}
 
@@ -154,7 +154,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.framework-artifact-id }}
 
@@ -187,7 +187,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: extensions
-          path: modules/extensions/repo/dev/galasa
+          path: modules/extensions/repo
           retention-days: 7
 
   report-failure:

--- a/overlays/.github/workflows/extensions.yaml
+++ b/overlays/.github/workflows/extensions.yaml
@@ -1,0 +1,204 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Extensions Main Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      jacoco_enabled:
+        description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
+        required: false
+        default: 'true'
+        type: string
+      sign_artifacts:
+        description: 'True if the artifacts built should be signed (set to "false" for development branch builds)'
+        required: false
+        default: 'true'
+        type: string
+      wrapping-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
+        required: true
+        type: string
+      gradle-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
+        required: true
+        type: string
+      maven-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
+        required: true
+        type: string
+      framework-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the framework module'
+        required: true
+        type: string
+
+env:
+  BRANCH: ${{ github.ref_name }}
+    
+jobs:
+
+  log-unchanged:
+    name: Extensions is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The extensions module is unchanged"
+
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+
+  build-extensions:
+    name: Build Extensions source code and Docker image for development Maven registry
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Setup JDK 
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+      
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+          cache-disabled: true
+
+      # For any modules that were changed in this push,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/wrapping/dev/galasa
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this push,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.wrapping-artifact-id }}
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.framework-artifact-id }}
+
+      - name: Build Extensions source code with gradle
+        working-directory: modules/extensions
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKeyId:  ${{ secrets.GPG_KEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -o pipefail
+          gradle -b galasa-extensions-parent/build.gradle check publish --info \
+          --no-daemon --console plain \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/modules/extensions/repo \
+          -PjacocoEnabled=${{ inputs.jacoco_enabled }} \
+          -PisMainOrRelease=${{ inputs.sign_artifacts }} 2>&1 | tee build.log
+
+      - name: Upload Gradle Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: extensions-gradle-build-log
+          path: modules/extensions/build.log
+
+      - name: Upload extensions artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: extensions
+          path: modules/extensions/repo/dev/galasa
+          retention-days: 7
+
+  # report-failure:
+  #   name: Report failure in workflow
+  #   runs-on: ubuntu-latest
+  #   needs: [log-github-ref, build-extensions]
+  #   if: failure()
+
+  #   steps:
+  #     - name: Report failure in workflow to Slack
+  #       env: 
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #       run : |
+  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "extensions" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/extensions.yaml
+++ b/overlays/.github/workflows/extensions.yaml
@@ -190,15 +190,15 @@ jobs:
           path: modules/extensions/repo/dev/galasa
           retention-days: 7
 
-  # report-failure:
-  #   name: Report failure in workflow
-  #   runs-on: ubuntu-latest
-  #   needs: [log-github-ref, build-extensions]
-  #   if: failure()
+  report-failure:
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [log-github-ref, build-extensions]
+    if: failure()
 
-  #   steps:
-  #     - name: Report failure in workflow to Slack
-  #       env: 
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #       run : |
-  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "extensions" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+    steps:
+      - name: Report failure in workflow to Slack
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run : |
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "extensions" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/framework.yaml
+++ b/overlays/.github/workflows/framework.yaml
@@ -209,10 +209,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          # username: galasa-team
-          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: galasa-team
+          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
         
       - name: Extract metadata for restapidoc-site image
         id: metadata
@@ -229,27 +227,27 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}  
       
-      # - name: Recycle application in ArgoCD
-      #   env: 
-      #       ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
-      #   run: |
-      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name restapidocsite-${{ env.BRANCH }} --server argocd.galasa.dev
+      - name: Recycle application in ArgoCD
+        env: 
+            ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name restapidocsite-${{ env.BRANCH }} --server argocd.galasa.dev
 
-      # - name: Wait for app health in ArgoCD
-      #   env: 
-      #     ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
-      #   run: |
-      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:restapidocsite-${{ env.BRANCH }} --health --server argocd.galasa.dev
+      - name: Wait for app health in ArgoCD
+        env: 
+          ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:restapidocsite-${{ env.BRANCH }} --health --server argocd.galasa.dev
 
-  # report-failure:
-  #   name: Report failure in workflow
-  #   runs-on: ubuntu-latest
-  #   needs: [log-github-ref, build-framework, build-rest-api-documentation]
-  #   if: failure()
+  report-failure:
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [log-github-ref, build-framework, build-rest-api-documentation]
+    if: failure()
 
-  #   steps:
-  #     - name: Report failure in workflow to Slack
-  #       env: 
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #       run : |
-  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "framework" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+    steps:
+      - name: Report failure in workflow to Slack
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run : |
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "framework" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/framework.yaml
+++ b/overlays/.github/workflows/framework.yaml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -107,7 +107,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -115,7 +115,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this push,
       # download artifacts from the last successful workflow.
@@ -125,7 +125,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.wrapping-artifact-id }}
 
@@ -134,7 +134,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -143,7 +143,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.maven-artifact-id }}
 
@@ -177,7 +177,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: framework
-          path: modules/framework/repo/dev/galasa
+          path: modules/framework/repo
           retention-days: 7
 
   build-rest-api-documentation:

--- a/overlays/.github/workflows/framework.yaml
+++ b/overlays/.github/workflows/framework.yaml
@@ -231,13 +231,13 @@ jobs:
         env: 
             ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |
-          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name restapidocsite-${{ env.BRANCH }} --server argocd.galasa.dev
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name restapidocsite-${{ env.BRANCH }} --server argocd.galasa.dev
 
       - name: Wait for app health in ArgoCD
         env: 
           ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
         run: |
-          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:restapidocsite-${{ env.BRANCH }} --health --server argocd.galasa.dev
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:restapidocsite-${{ env.BRANCH }} --health --server argocd.galasa.dev
 
   report-failure:
     name: Report failure in workflow

--- a/overlays/.github/workflows/framework.yaml
+++ b/overlays/.github/workflows/framework.yaml
@@ -1,0 +1,255 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Framework Main Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      jacoco_enabled:
+        description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
+        required: false
+        default: 'true'
+        type: string
+      sign_artifacts:
+        description: 'True if the artifacts built should be signed (set to "false" for development branch builds)'
+        required: false
+        default: 'true'
+        type: string
+      wrapping-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
+        required: true
+        type: string
+      gradle-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
+        required: true
+        type: string
+      maven-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  NAMESPACE: ${{ github.repository_owner }}
+  BRANCH: ${{ github.ref_name }}
+    
+jobs:
+
+  log-unchanged:
+    name: Framework is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The framework module is unchanged"
+
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+
+  build-framework:
+    name: Build Framework using openapi2beans and gradle
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Setup JDK 
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+        
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+          cache-disabled: true
+      
+      - name: Build servlet beans with openapi2beans
+        env:
+          YAML_LOCATION: "modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml"
+          OUTPUT_LOCATION: "modules/framework/galasa-parent/dev.galasa.framework.api.beans/src/main/java"
+          PACKAGE: "dev.galasa.framework.api.beans.generated"
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/openapi2beans:main generate --yaml var/workspace/${{ env.YAML_LOCATION }} --output var/workspace/${{ env.OUTPUT_LOCATION }} --package ${{ env.PACKAGE }}
+
+      # For any modules that were changed in this push,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this push,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.wrapping-artifact-id }}
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Build Framework source code
+        working-directory: modules/framework
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKeyId:  ${{ secrets.GPG_KEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -o pipefail
+          gradle -b galasa-parent/build.gradle check publish --info \
+          --no-daemon --console plain \
+          -Dorg.gradle.jvmargs=-Xmx5120M \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/modules/framework/repo \
+          -PjacocoEnabled=${{ inputs.jacoco_enabled }} \
+          -PisMainOrRelease=${{ inputs.sign_artifacts }} 2>&1 | tee build.log
+
+      - name: Upload Gradle Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: framework-gradle-build-log
+          path: modules/framework/build.log
+
+      - name: Upload framework artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: framework
+          path: modules/framework/repo/dev/galasa
+          retention-days: 7
+
+  build-rest-api-documentation:
+    name: Build REST API documentation using openapi2beans and gradle
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Setup JDK 
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+      
+      - name: Install Swagger CLI
+        working-directory: modules/framework
+        run: |
+          wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.41/swagger-codegen-cli-3.0.41.jar -O swagger-codegen-cli.jar
+      
+      - name: Generate Swagger docs
+        working-directory: modules/framework
+        run: |
+          java -jar swagger-codegen-cli.jar generate -i galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml -l html2 -o docs/generated/galasaapi
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          # username: galasa-team
+          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+        
+      - name: Extract metadata for restapidoc-site image
+        id: metadata
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ghcr.io/${{ env.NAMESPACE }}/restapidoc-site
+                
+      - name: Build and push restapidoc-site image
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/framework
+          file: modules/framework/dockerfiles/dockerfile.restapidocsite
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}  
+      
+      # - name: Recycle application in ArgoCD
+      #   env: 
+      #       ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+      #   run: |
+      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name restapidocsite-${{ env.BRANCH }} --server argocd.galasa.dev
+
+      # - name: Wait for app health in ArgoCD
+      #   env: 
+      #     ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+      #   run: |
+      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:restapidocsite-${{ env.BRANCH }} --health --server argocd.galasa.dev
+
+  # report-failure:
+  #   name: Report failure in workflow
+  #   runs-on: ubuntu-latest
+  #   needs: [log-github-ref, build-framework, build-rest-api-documentation]
+  #   if: failure()
+
+  #   steps:
+  #     - name: Report failure in workflow to Slack
+  #       env: 
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #       run : |
+  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "framework" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/gradle.yaml
+++ b/overlays/.github/workflows/gradle.yaml
@@ -98,15 +98,15 @@ jobs:
           path: modules/gradle/repo/dev/galasa
           retention-days: 7
 
-  # report-failure:
-  #   name: Report failure in workflow
-  #   runs-on: ubuntu-latest
-  #   needs: [log-github-ref, build-gradle]
-  #   if: failure()
+  report-failure:
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [log-github-ref, build-gradle]
+    if: failure()
 
-  #   steps:
-  #     - name: Report failure in workflow to Slack
-  #       env: 
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #       run : |
-  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "gradle" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+    steps:
+      - name: Report failure in workflow to Slack
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run : |
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "gradle" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/gradle.yaml
+++ b/overlays/.github/workflows/gradle.yaml
@@ -95,7 +95,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: gradle
-          path: modules/gradle/repo/dev/galasa
+          path: modules/gradle/repo
           retention-days: 7
 
   report-failure:

--- a/overlays/.github/workflows/gradle.yaml
+++ b/overlays/.github/workflows/gradle.yaml
@@ -1,0 +1,112 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Gradle Main Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      jacoco_enabled:
+        description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
+        required: false
+        default: 'true'
+        type: string
+      sign_artifacts:
+        description: 'True if the artifacts built should be signed (set to "false" for development branch builds)'
+        required: false
+        default: 'true'
+        type: string
+
+env:
+  BRANCH: ${{ github.ref_name }}
+
+jobs:
+
+  log-unchanged:
+    name: Gradle is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The gradle module is unchanged"
+
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+
+  build-gradle:
+    name: Build 'gradle' source code
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+          cache-disabled: true
+
+      - name: Build Gradle source code
+        working-directory: modules/gradle
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKeyId:  ${{ secrets.GPG_KEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -o pipefail
+          gradle check publish --info \
+          --no-daemon --console plain \
+          -PsourceMaven=https://repo.maven.apache.org/maven2/ \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/modules/gradle/repo \
+          -PjacocoEnabled=${{ inputs.jacoco_enabled }} \
+          -PisMainOrRelease=${{ inputs.sign_artifacts }} 2>&1 | tee build.log
+
+      - name: Upload Gradle Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradle-gradle-build-log
+          path: modules/gradle/build.log
+
+      - name: Upload gradle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradle
+          path: modules/gradle/repo/dev/galasa
+          retention-days: 7
+
+  # report-failure:
+  #   name: Report failure in workflow
+  #   runs-on: ubuntu-latest
+  #   needs: [log-github-ref, build-gradle]
+  #   if: failure()
+
+  #   steps:
+  #     - name: Report failure in workflow to Slack
+  #       env: 
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #       run : |
+  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "gradle" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/managers.yaml
+++ b/overlays/.github/workflows/managers.yaml
@@ -1,0 +1,215 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Managers Main Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      jacoco_enabled:
+        description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
+        required: false
+        default: 'true'
+        type: string
+      sign_artifacts:
+        description: 'True if the artifacts built should be signed (set to "false" for development branch builds)'
+        required: false
+        default: 'true'
+        type: string
+      wrapping-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
+        required: true
+        type: string
+      gradle-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
+        required: true
+        type: string
+      maven-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
+        required: true
+        type: string
+      framework-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the framework module'
+        required: true
+        type: string
+
+env:
+  BRANCH: ${{ github.ref_name }}
+
+jobs:
+
+  log-unchanged:
+    name: Managers is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The managers module is unchanged"
+
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+
+  build-managers:
+    name: Build Managers source code and Docker image for development Maven registry
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Setup JDK 
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+          cache-disabled: true
+
+      # For any modules that were changed in this push,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/wrapping/dev/galasa
+  
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this push,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.wrapping-artifact-id }}
+  
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.framework-artifact-id }}
+
+      - name: Build Managers source code
+        working-directory: modules/managers
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG_GRADLE_PROJECT_signingKeyId:  ${{ secrets.GPG_KEYID }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          set -o pipefail
+          gradle -b galasa-managers-parent/build.gradle check publish --info \
+          --no-daemon --console plain \
+          -Dorg.gradle.jvmargs=-Xmx4096M \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/modules/managers/repo \
+          -PjacocoEnabled=${{ inputs.jacoco_enabled }} \
+          -PisMainOrRelease=${{ inputs.sign_artifacts }} 2>&1 | tee build.log
+        
+      - name: Upload Gradle Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: managers-gradle-build-log
+          path: modules/managers/build.log
+          retention-days: 7
+          
+      - name: Upload Jacoco Report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: managers-jacoco-report
+          path: ${{ github.workspace }}/galasa-managers-parent/**/**/build/reports/**/*.html
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload managers artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: managers
+          path: modules/managers/repo/dev/galasa
+          retention-days: 7
+
+  # report-failure:
+  #   name: Report failure in workflow
+  #   runs-on: ubuntu-latest
+  #   needs: [log-github-ref, build-managers]
+  #   if: failure()
+
+  #   steps:
+  #     - name: Report failure in workflow to Slack
+  #       env: 
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #       run : |
+  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "managers" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/managers.yaml
+++ b/overlays/.github/workflows/managers.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/wrapping/dev/galasa
+          path: modules/artifacts
   
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -101,7 +101,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -109,7 +109,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download framework artifacts from this workflow
         id: download-framework
@@ -117,7 +117,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this push,
       # download artifacts from the last successful workflow.
@@ -127,7 +127,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.wrapping-artifact-id }}
   
@@ -136,7 +136,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -145,7 +145,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.maven-artifact-id }}
 
@@ -154,7 +154,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.framework-artifact-id }}
 
@@ -198,7 +198,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: managers
-          path: modules/managers/repo/dev/galasa
+          path: modules/managers/repo
           retention-days: 7
 
   report-failure:

--- a/overlays/.github/workflows/managers.yaml
+++ b/overlays/.github/workflows/managers.yaml
@@ -201,15 +201,15 @@ jobs:
           path: modules/managers/repo/dev/galasa
           retention-days: 7
 
-  # report-failure:
-  #   name: Report failure in workflow
-  #   runs-on: ubuntu-latest
-  #   needs: [log-github-ref, build-managers]
-  #   if: failure()
+  report-failure:
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [log-github-ref, build-managers]
+    if: failure()
 
-  #   steps:
-  #     - name: Report failure in workflow to Slack
-  #       env: 
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #       run : |
-  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "managers" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+    steps:
+      - name: Report failure in workflow to Slack
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run : |
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "managers" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/maven.yaml
+++ b/overlays/.github/workflows/maven.yaml
@@ -1,0 +1,176 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Maven Main Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      jacoco_enabled:
+        description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
+        required: false
+        default: 'true'
+        type: string
+      sign_artifacts:
+        description: 'True if the artifacts built should be signed (set to "false" for development branch builds)'
+        required: false
+        default: 'true'
+        type: string
+      gradle-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
+        required: true
+        type: string
+
+env:
+  BRANCH: ${{ github.ref_name }}
+
+jobs:
+
+  log-unchanged:
+    name: Maven is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The maven module is unchanged"
+
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+
+  build-maven:
+    name: Build Maven source code and Docker image for development Maven registry
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      # Copy secrets into files to use in workflow
+      - name: Make secrets directory
+        run : |
+          mkdir /home/runner/work/secrets
+
+      - name: Copy settings.xml
+        env:
+          MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+        run : |
+          echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+
+      - name: Copy GPG passphrase
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run : |
+          echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+
+      - name: Copy GPG key
+        env:
+          GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+        run : |
+          echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+          
+      # Set up Maven GPG directory
+      - name: Make GPG home directory
+        run: |
+          mkdir /home/runner/work/gpg
+      
+      - name: Change directory permissions
+        run: |
+          chmod '700' /home/runner/work/gpg
+
+      - name: Import GPG
+        run: |
+          gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+      
+      - name: Copy custom settings.xml
+        run: |
+          cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+
+      # For any modules that were changed in this push,
+      # download their artifacts from this workflow run.
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this push,
+      # download artifacts from the last successful workflow.
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Build Maven source code
+        working-directory: modules/maven
+        run: |
+          set -o pipefail
+          mvn -f galasa-maven-plugin/pom.xml deploy -X \
+          -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/modules/maven/repo \
+          -Dgalasa.jacocoEnabled=${{ inputs.jacoco_enabled }} \
+          -Dgalasa.isRelease=${{ inputs.sign_artifacts }} \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
+      
+      - name: Upload Maven Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-maven-build-log
+          path: modules/maven/build.log
+            
+      - name: Upload Junit Test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-test-report
+          path: modules/maven/galasa-maven-plugin/target/surefire-reports
+
+      - name: Upload maven artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven
+          path: modules/maven/repo/dev/galasa
+          retention-days: 7
+
+  # report-failure:
+  #   name: Report failure in workflow
+  #   runs-on: ubuntu-latest
+  #   needs: [log-github-ref, build-maven]
+  #   if: failure()
+
+  #   steps:
+  #     - name: Report failure in workflow to Slack
+  #       env: 
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #       run : |
+  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "maven" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/maven.yaml
+++ b/overlays/.github/workflows/maven.yaml
@@ -162,15 +162,15 @@ jobs:
           path: modules/maven/repo/dev/galasa
           retention-days: 7
 
-  # report-failure:
-  #   name: Report failure in workflow
-  #   runs-on: ubuntu-latest
-  #   needs: [log-github-ref, build-maven]
-  #   if: failure()
+  report-failure:
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [log-github-ref, build-maven]
+    if: failure()
 
-  #   steps:
-  #     - name: Report failure in workflow to Slack
-  #       env: 
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #       run : |
-  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "maven" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+    steps:
+      - name: Report failure in workflow to Slack
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run : |
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "maven" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/maven.yaml
+++ b/overlays/.github/workflows/maven.yaml
@@ -114,7 +114,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this push,
       # download artifacts from the last successful workflow.
@@ -124,7 +124,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -159,7 +159,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: maven
-          path: modules/maven/repo/dev/galasa
+          path: modules/maven/repo
           retention-days: 7
 
   report-failure:

--- a/overlays/.github/workflows/obr.yaml
+++ b/overlays/.github/workflows/obr.yaml
@@ -292,10 +292,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          # username: galasa-team
-          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: galasa-team
+          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
     
       - name: Extract metadata for OBR image
         id: metadata-obr
@@ -316,13 +314,13 @@ jobs:
             dockerRepository=${{ env.REGISTRY }}
             tag=${{ env.BRANCH }}
       
-      # - name: Recycle OBR application in ArgoCD
-      #   run: |
-      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name obr-${{ env.BRANCH }} --server argocd.galasa.dev
+      - name: Recycle OBR application in ArgoCD
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/galasa-dev/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name obr-${{ env.BRANCH }} --server argocd.galasa.dev
 
-      # - name: Wait for OBR application health in ArgoCD
-      #   run: |
-      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:obr-${{ env.BRANCH }} --health --server argocd.galasa.dev
+      - name: Wait for OBR application health in ArgoCD
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:obr-${{ env.BRANCH }} --health --server argocd.galasa.dev
     
 
   build-obr-javadocs:
@@ -515,10 +513,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          # username: galasa-team
-          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: galasa-team
+          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
     
       - name: Extract metadata for Javadoc site image
         id: metadata-javadoc-site
@@ -536,13 +532,13 @@ jobs:
           tags: ${{ steps.metadata-javadoc-site.outputs.tags }}
           labels: ${{ steps.metadata-javadoc-site.outputs.labels }}
       
-      # - name: Recycle javadocsite application in ArgoCD
-      #   run: |
-      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name javadocsite-${{ env.BRANCH }} --server argocd.galasa.dev
+      - name: Recycle javadocsite application in ArgoCD
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name javadocsite-${{ env.BRANCH }} --server argocd.galasa.dev
       
-      # - name: Wait for javadocsite application health in ArgoCD
-      #   run: |
-      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:javadocsite-${{ env.BRANCH }} --health --server argocd.galasa.dev
+      - name: Wait for javadocsite application health in ArgoCD
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:javadocsite-${{ env.BRANCH }} --health --server argocd.galasa.dev
       
       - name: Extract metadata for Javadoc Maven repo image
         id: metadata
@@ -563,13 +559,13 @@ jobs:
             dockerRepository=${{ env.REGISTRY }}
             baseVersion=latest
           
-      # - name: Recycle javadoc application in ArgoCD
-      #   run: |
-      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name javadoc-${{ env.BRANCH }} --server argocd.galasa.dev
+      - name: Recycle javadoc application in ArgoCD
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name javadoc-${{ env.BRANCH }} --server argocd.galasa.dev
 
-      # - name: Wait for javadoc application health in ArgoCD
-      #   run: |
-      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:javadoc-${{ env.BRANCH }} --health --server argocd.galasa.dev
+      - name: Wait for javadoc application health in ArgoCD
+        run: |
+          docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:javadoc-${{ env.BRANCH }} --health --server argocd.galasa.dev
 
   build-obr-generic:
     name: Build OBR embedded and boot images using galasabld and maven
@@ -769,10 +765,8 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          # username: galasa-team
-          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: galasa-team
+          password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
     
       - name: Extract metadata for OBR generic image
         id: metadata-obr-generic
@@ -837,49 +831,49 @@ jobs:
             dockerRepository=${{ env.REGISTRY }}
             platform=x86_64
 
-  # trigger-next-workflows:
-  #   name: Trigger next workflows in the build chain
-  #   if: ${{ inputs.changed == 'true' }}
-  #   needs: [build-obr, build-obr-generic, build-obr-javadocs]
-  #   runs-on: ubuntu-latest
+  trigger-next-workflows:
+    name: Trigger next workflows in the build chain
+    if: ${{ inputs.changed == 'true' }}
+    needs: [build-obr, build-obr-generic, build-obr-javadocs]
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #     - name: Triggering helm build (github.ref is main)
-  #       if: ${{ env.BRANCH == 'main' }}
-  #       env:
-  #         GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-  #       run: |
-  #         gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation --ref ${{ env.BRANCH }}
+    steps:
+      - name: Triggering helm build (github.ref is main)
+        if: ${{ env.BRANCH == 'main' }}
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation --ref ${{ env.BRANCH }}
 
-  #     - name: Triggering integratedtests build (github.ref is main)
-  #       if: ${{ env.BRANCH == 'main' }}
-  #       env:
-  #         GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-  #       run: |
-  #         gh workflow run build.yaml --repo https://github.com/galasa-dev/integratedtests --ref ${{ env.BRANCH }}
+      - name: Triggering integratedtests build (github.ref is main)
+        if: ${{ env.BRANCH == 'main' }}
+        env:
+          GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/integratedtests --ref ${{ env.BRANCH }}
         
-  #     - name: Triggering cli build (github.ref is not main) 
-  #       if: ${{ env.BRANCH != 'main' }}
-  #       env:
-  #           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-  #       run: |
-  #         gh workflow run build.yml --repo https://github.com/galasa-dev/cli --ref ${{ env.BRANCH }}
+      - name: Triggering cli build (github.ref is not main) 
+        if: ${{ env.BRANCH != 'main' }}
+        env:
+            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yml --repo https://github.com/galasa-dev/cli --ref ${{ env.BRANCH }}
 
-  #     - name: Triggering simplatform build
-  #       env:
-  #           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
-  #       run: |
-  #         gh workflow run build.yaml --repo https://github.com/galasa-dev/simplatform --ref ${{ env.BRANCH }}
+      - name: Triggering simplatform build
+        env:
+            GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yaml --repo https://github.com/galasa-dev/simplatform --ref ${{ env.BRANCH }}
 
-  # report-failure:
-  #   name: Report failure in workflow
-  #   runs-on: ubuntu-latest
-  #   needs: [log-github-ref, build-obr, build-obr-javadocs, build-obr-generic, trigger-next-workflows]
-  #   if: failure()
+  report-failure:
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [log-github-ref, build-obr, build-obr-javadocs, build-obr-generic, trigger-next-workflows]
+    if: failure()
 
-  #   steps:
-  #     - name: Report failure in workflow to Slack
-  #       env: 
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #       run : |
-  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "obr" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+    steps:
+      - name: Report failure in workflow to Slack
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run : |
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "obr" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/obr.yaml
+++ b/overlays/.github/workflows/obr.yaml
@@ -1,0 +1,851 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: OBR Main Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      wrapping-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
+        required: true
+        type: string
+      gradle-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
+        required: true
+        type: string
+      maven-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
+        required: true
+        type: string
+      framework-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the framework module'
+        required: true
+        type: string
+      extensions-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the extensions module'
+        required: true
+        type: string
+      managers-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the managers module'
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  NAMESPACE: ${{ github.repository_owner }}
+  BRANCH: ${{ github.ref_name }}
+  ARGOCD_AUTH_TOKEN: ${{ secrets.ARGOCD_TOKEN }}
+
+jobs:
+
+  log-unchanged:
+    name: OBR is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The obr module is unchanged"
+
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+          
+  build-obr:
+    name: Build OBR using galasabld image and maven
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+  
+      - name: Print githash
+        working-directory: modules/obr
+        run: |
+          echo $GITHUB_SHA > ./obr.githash
+
+      - name: Make secrets directory
+        run : |
+            mkdir /home/runner/work/secrets
+
+      - name: Copy settings.xml
+        env:
+            MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+        run : |
+            echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+      
+      - name: Copy GPG passphrase
+        env:
+            GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run : |
+            echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+      
+      - name: Copy GPG key
+        env:
+            GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+        run : |
+            echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+            
+      - name: Make GPG home directory and change permissions
+        run: |
+            mkdir /home/runner/work/gpg
+            chmod '700' /home/runner/work/gpg
+        
+      - name: Import GPG
+        run: |
+            gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+        
+      - name: Copy custom settings.xml
+        run: |
+            cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+      
+      - name:  Generate Galasa BOM
+        run: |
+          docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/galasa-bom/pom.template --output /var/root/obr/galasa-bom/pom.xml --bom
+          
+      - name: Display Galasa BOM pom.xml
+        run: |
+          cat modules/obr/galasa-bom/pom.xml
+
+      # For any modules that were changed in this push,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+
+      - name: Download extensions artifacts from this workflow
+        id: download-extensions
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts/dev/galasa
+
+      - name: Download managers artifacts from this workflow
+        id: download-managers
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: managers
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this push,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.wrapping-artifact-id }}
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.framework-artifact-id }}
+
+      - name: Download extensions artifacts from last successful workflow
+        if: ${{ steps.download-extensions.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.extensions-artifact-id }}
+
+      - name: Download managers artifacts from last successful workflow
+        if: ${{ steps.download-managers.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: managers
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.managers-artifact-id }}
+        
+      - name: Build Galasa BOM with maven
+        working-directory: modules/obr
+        run: |
+          set -o pipefail
+          mvn -f galasa-bom/pom.xml deploy -X \
+          -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/repo \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-bom-build.log
+        
+      - name: Upload Galasa BOM Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: galasa-bom-build-log
+          path: modules/obr/galasa-bom-build.log
+          retention-days: 7
+      
+      - name:  Generate Galasa OBR
+        run: |
+          docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/dev.galasa.uber.obr/pom.template --output /var/root/obr/dev.galasa.uber.obr/pom.xml --obr
+          
+      - name: Display Galasa OBR pom.xml
+        run: |
+          cat modules/obr/dev.galasa.uber.obr/pom.xml
+        
+      - name: Build Galasa OBR with maven
+        working-directory: modules/obr
+        run: |
+          set -o pipefail
+          mvn -f dev.galasa.uber.obr/pom.xml deploy -X \
+          -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/repo \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-obr-build.log
+    
+      - name: Upload Galasa OBR Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: galasa-obr-build-log
+          path: modules/obr/galasa-obr-build.log
+          retention-days: 7
+
+      - name: Upload obr artifacts
+        uses: actions/upload-artifact@v4
+        with:
+            name: obr
+            path: modules/obr/repo/dev/galasa
+            retention-days: 7
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          # username: galasa-team
+          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+    
+      - name: Extract metadata for OBR image
+        id: metadata-obr
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/obr-maven-artefacts
+
+      - name: Build and push OBR image 
+        id: build-obr
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/obr
+          file: modules/obr/dockerfiles/dockerfile.obr
+          push: true
+          tags: ${{ steps.metadata-obr.outputs.tags }}
+          labels: ${{ steps.metadata-obr.outputs.labels }}
+          build-args: |
+            dockerRepository=${{ env.REGISTRY }}
+            tag=${{ env.BRANCH }}
+      
+      # - name: Recycle OBR application in ArgoCD
+      #   run: |
+      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name obr-${{ env.BRANCH }} --server argocd.galasa.dev
+
+      # - name: Wait for OBR application health in ArgoCD
+      #   run: |
+      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:obr-${{ env.BRANCH }} --health --server argocd.galasa.dev
+    
+
+  build-obr-javadocs:
+    name: Build OBR javadocs using galasabld image and maven
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+      
+      - name: Make secrets directory
+        run : |
+            mkdir /home/runner/work/secrets
+
+      - name: Copy settings.xml 
+        env:
+          MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+        run : |
+          echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+
+      - name: Copy GPG passphrase
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run : |
+          echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+
+      - name: Copy GPG key
+        env:
+          GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+        run : |
+          echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+          
+      - name: Make GPG home directory and change permissions
+        run: |
+          mkdir /home/runner/work/gpg
+          chmod '700' /home/runner/work/gpg
+
+      - name: Import GPG
+        run: |
+          gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+      
+      - name: Copy custom settings.xml
+        run: |
+          cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+          
+      - name: Build Galasa Javadoc
+        run: |
+            docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/javadocs/pom.template --output /var/root/obr/javadocs/pom.xml --javadoc
+            
+      - name: Display Galasa Javadoc pom.xml 
+        run: |
+          cat modules/obr/javadocs/pom.xml
+
+      # For any modules that were changed in this push,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+
+      - name: Download extensions artifacts from this workflow
+        id: download-extensions
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts/dev/galasa
+
+      - name: Download managers artifacts from this workflow
+        id: download-managers
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: managers
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this push,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.wrapping-artifact-id }}
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.framework-artifact-id }}
+
+      - name: Download extensions artifacts from last successful workflow
+        if: ${{ steps.download-extensions.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.extensions-artifact-id }}
+
+      - name: Download managers artifacts from last successful workflow
+        if: ${{ steps.download-managers.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: managers
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.managers-artifact-id }}
+        
+      - name: Build javadoc site using maven
+        working-directory: modules/obr/javadocs
+        run: |
+          set -o pipefail
+          mvn -f pom.xml deploy -X \
+          -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/javadocs/docker/repo \
+          -Dmaven.javadoc.failOnError=false \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
+      
+      - name: Upload javadoc site Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: javadoc-site-build-log
+          path: modules/obr/javadocs/build.log
+          retention-days: 7
+      
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          # username: galasa-team
+          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+    
+      - name: Extract metadata for Javadoc site image
+        id: metadata-javadoc-site
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/javadoc-site
+  
+      - name: Build and push Javadoc site image 
+        id: build-javadoc-site
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/obr
+          file: modules/obr/dockerfiles/dockerfile.javadocsite
+          push: true
+          tags: ${{ steps.metadata-javadoc-site.outputs.tags }}
+          labels: ${{ steps.metadata-javadoc-site.outputs.labels }}
+      
+      # - name: Recycle javadocsite application in ArgoCD
+      #   run: |
+      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name javadocsite-${{ env.BRANCH }} --server argocd.galasa.dev
+      
+      # - name: Wait for javadocsite application health in ArgoCD
+      #   run: |
+      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:javadocsite-${{ env.BRANCH }} --health --server argocd.galasa.dev
+      
+      - name: Extract metadata for Javadoc Maven repo image
+        id: metadata
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/javadoc-maven-artefacts
+    
+      - name: Build and push Javadoc Maven repo image 
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/obr
+          file: modules/obr/dockerfiles/dockerfile.javadocmavenrepo
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}
+          build-args: |
+            dockerRepository=${{ env.REGISTRY }}
+            baseVersion=latest
+          
+      # - name: Recycle javadoc application in ArgoCD
+      #   run: |
+      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app actions run ${{ env.BRANCH }}-maven-repos restart --kind Deployment --resource-name javadoc-${{ env.BRANCH }} --server argocd.galasa.dev
+
+      # - name: Wait for javadoc application health in ArgoCD
+      #   run: |
+      #     docker run --env ARGOCD_AUTH_TOKEN=${{ env.ARGOCD_AUTH_TOKEN }} --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/argocdcli:main app wait ${{ env.BRANCH }}-maven-repos --resource apps:Deployment:javadoc-${{ env.BRANCH }} --health --server argocd.galasa.dev
+
+  build-obr-generic:
+    name: Build OBR embedded and boot images using galasabld and maven
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    needs: [build-obr, build-obr-javadocs]
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      - name: Make secrets directory
+        run : |
+            mkdir /home/runner/work/secrets
+
+      - name: Copy settings.xml
+        env:
+            MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+        run : |
+            echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+      
+      - name: Copy GPG passphrase
+        env:
+            GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run : |
+            echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+      
+      - name: Copy GPG key
+        env:
+            GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+        run : |
+            echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+            
+      - name: Make GPG home directory and change permissions
+        run: |
+            mkdir /home/runner/work/gpg
+            chmod '700' /home/runner/work/gpg
+        
+      - name: Import GPG
+        run: |
+            gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+        
+      - name: Copy custom settings.xml
+        run: |
+            cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+      
+      - name:  Generate Galasa OBR generic pom.xml
+        run: |
+          docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/obr-generic/pom.template --output /var/root/obr/obr-generic/pom.xml --obr
+           
+      - name: Display Galasa OBR generic pom.xml
+        run: |
+          cat modules/obr/obr-generic/pom.xml
+
+      # For any modules that were changed in this push,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+
+      - name: Download extensions artifacts from this workflow
+        id: download-extensions
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts/dev/galasa
+
+      - name: Download managers artifacts from this workflow
+        id: download-managers
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: managers
+          path: modules/artifacts/dev/galasa
+
+      - name: Download obr artifacts
+        id: download-obr
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: obr
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this push,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.wrapping-artifact-id }}
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.framework-artifact-id }}
+
+      - name: Download extensions artifacts from last successful workflow
+        if: ${{ steps.download-extensions.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.extensions-artifact-id }}
+
+      - name: Download managers artifacts from last successful workflow
+        if: ${{ steps.download-managers.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: managers
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.managers-artifact-id }}
+        
+      - name: Build Galasa OBR generic pom.xml with maven
+        working-directory: modules/obr/obr-generic
+        run: |
+          set -o pipefail
+          mvn -f pom.xml process-sources -X \
+          -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          dev.galasa:galasa-maven-plugin:0.15.0:obrembedded \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
+        
+      - name: Upload galasa obr generic Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: galasa-obr-generic-build-log
+          path: modules/obr/obr-generic/build.log
+          retention-days: 7
+
+      - name: Login to Github Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          # username: galasa-team
+          # password: ${{ secrets.GALASA_TEAM_WRITE_PACKAGES_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+    
+      - name: Extract metadata for OBR generic image
+        id: metadata-obr-generic
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/obr-generic
+  
+      - name: Build and push obr-generic
+        id: build-obr-generic
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/obr
+          file: modules/obr/dockerfiles/dockerfile.obrgeneric
+          push: true
+          tags: ${{ steps.metadata-obr-generic.outputs.tags }}
+          labels: ${{ steps.metadata-obr-generic.outputs.labels }}
+
+      - name: Copy files from kubectl image for Galasa boot embedded images
+        run: |
+          mkdir -p /opt/k8s/bin
+          curl -L https://dl.k8s.io/release/v1.22.0/bin/linux/amd64/kubectl -o /opt/k8s/bin/kubectl
+          chmod +x /opt/k8s/bin/kubectl
+          cp -vr /opt/k8s/bin/kubectl ${{ github.workspace }}/modules/obr/dockerfiles/trace-log4j.properties ${{ github.workspace }}/modules/obr/obr-generic/
+
+      - name: Extract metadata for Galasa boot embedded image
+        id: metadata-boot-embedded
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasa-boot-embedded-x86_64
+  
+      - name: Build and push Galasa boot embedded image
+        id: build-boot-embedded
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/obr
+          file: modules/obr/dockerfiles/dockerfile.bootembedded
+          push: true
+          tags: ${{ steps.metadata-boot-embedded.outputs.tags }}
+          labels: ${{ steps.metadata-boot-embedded.outputs.labels }}
+          build-args: |
+            tag=${{ env.BRANCH }}
+            dockerRepository=${{ env.REGISTRY }}
+            jdkImage=harbor.galasa.dev/docker_proxy_cache/library/openjdk:17
+
+      - name: Extract metadata for Galasa IBM boot embedded image
+        id: metadata-ibm-boot-embedded
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/galasa-ibm-boot-embedded-x86_64
+  
+      - name: Build and push Galasa IBM boot embedded image
+        id: build-ibm-boot-embedded
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/obr
+          file: modules/obr/dockerfiles/dockerfile.ibmbootembedded
+          push: true
+          tags: ${{ steps.metadata-ibm-boot-embedded.outputs.tags }}
+          labels: ${{ steps.metadata-ibm-boot-embedded.outputs.labels }}
+          build-args: |
+            tag=${{ env.BRANCH }}
+            dockerRepository=${{ env.REGISTRY }}
+            platform=x86_64
+
+  # report-failure:
+  #   name: Report failure in workflow
+  #   runs-on: ubuntu-latest
+  #   needs: [log-github-ref, build-obr, build-obr-javadocs, build-obr-generic]
+  #   if: failure()
+
+  #   steps:
+  #     - name: Report failure in workflow to Slack
+  #       env: 
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #       run : |
+  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "obr" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/obr.yaml
+++ b/overlays/.github/workflows/obr.yaml
@@ -78,11 +78,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'semeru'
-  
-      - name: Print githash
-        working-directory: modules/obr
-        run: |
-          echo $GITHUB_SHA > ./obr.githash
 
       - name: Make secrets directory
         run : |
@@ -286,7 +281,18 @@ jobs:
       # All other module's artifacts were placed in the source repo previously in the workflow.
       - name: Copy source repo into release repo
         run: |
-          cp -R ${{ github.workspace }}/modules/artifacts ${{ github.workspace }}/modules/obr/repo
+          cp -R ${{ github.workspace }}/modules/artifacts/dev/galasa/* ${{ github.workspace }}/modules/obr/repo/dev/galasa
+
+      - name: Add githashes of each module to OBR image
+        run: |
+          echo $(git log -1 --pretty=format:"%H" -- "modules/buildutils") > modules/obr/buildutils.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/wrapping") > modules/obr/wrapping.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/gradle") > modules/obr/gradle.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/maven") > modules/obr/maven.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/framework") > modules/obr/framework.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/extensions") > modules/obr/extensions.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/managers") > modules/obr/managers.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/obr") > modules/obr/obr.githash
 
       - name: Upload obr artifacts
         uses: actions/upload-artifact@v4

--- a/overlays/.github/workflows/obr.yaml
+++ b/overlays/.github/workflows/obr.yaml
@@ -281,12 +281,19 @@ jobs:
           path: modules/obr/galasa-obr-build.log
           retention-days: 7
 
+      # The obr-maven-artefacts image which is built from the release repo's directory
+      # needs not only the obr module's artifacts but all other module's artifacts.
+      # All other module's artifacts were placed in the source repo previously in the workflow.
+      - name: Copy source repo into release repo
+        run: |
+          cp -R ${{ github.workspace }}/modules/artifacts ${{ github.workspace }}/modules/obr/repo
+
       - name: Upload obr artifacts
         uses: actions/upload-artifact@v4
         with:
-            name: obr
-            path: modules/obr/repo/dev/galasa
-            retention-days: 7
+          name: obr
+          path: modules/obr/repo
+          retention-days: 7
 
       - name: Login to Github Container Registry
         uses: docker/login-action@v3

--- a/overlays/.github/workflows/obr.yaml
+++ b/overlays/.github/workflows/obr.yaml
@@ -388,7 +388,7 @@ jobs:
           
       - name: Build Galasa Javadoc
         run: |
-            docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/javadocs/pom.template --output /var/root/obr/javadocs/pom.xml --javadoc
+          docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/javadocs/pom.template --output /var/root/obr/javadocs/pom.xml --javadoc
             
       - name: Display Galasa Javadoc pom.xml 
         run: |

--- a/overlays/.github/workflows/obr.yaml
+++ b/overlays/.github/workflows/obr.yaml
@@ -837,10 +837,44 @@ jobs:
             dockerRepository=${{ env.REGISTRY }}
             platform=x86_64
 
+  # trigger-next-workflows:
+  #   name: Trigger next workflows in the build chain
+  #   if: ${{ inputs.changed == 'true' }}
+  #   needs: [build-obr, build-obr-generic, build-obr-javadocs]
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #     - name: Triggering helm build (github.ref is main)
+  #       if: ${{ env.BRANCH == 'main' }}
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+  #       run: |
+  #         gh workflow run build-helm.yaml --repo https://github.com/galasa-dev/automation --ref ${{ env.BRANCH }}
+
+  #     - name: Triggering integratedtests build (github.ref is main)
+  #       if: ${{ env.BRANCH == 'main' }}
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+  #       run: |
+  #         gh workflow run build.yaml --repo https://github.com/galasa-dev/integratedtests --ref ${{ env.BRANCH }}
+        
+  #     - name: Triggering cli build (github.ref is not main) 
+  #       if: ${{ env.BRANCH != 'main' }}
+  #       env:
+  #           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+  #       run: |
+  #         gh workflow run build.yml --repo https://github.com/galasa-dev/cli --ref ${{ env.BRANCH }}
+
+  #     - name: Triggering simplatform build
+  #       env:
+  #           GH_TOKEN: ${{ secrets.GALASA_TEAM_GITHUB_TOKEN }}
+  #       run: |
+  #         gh workflow run build.yaml --repo https://github.com/galasa-dev/simplatform --ref ${{ env.BRANCH }}
+
   # report-failure:
   #   name: Report failure in workflow
   #   runs-on: ubuntu-latest
-  #   needs: [log-github-ref, build-obr, build-obr-javadocs, build-obr-generic]
+  #   needs: [log-github-ref, build-obr, build-obr-javadocs, build-obr-generic, trigger-next-workflows]
   #   if: failure()
 
   #   steps:

--- a/overlays/.github/workflows/obr.yaml
+++ b/overlays/.github/workflows/obr.yaml
@@ -131,7 +131,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -139,7 +139,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -147,7 +147,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download framework artifacts from this workflow
         id: download-framework
@@ -155,7 +155,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download extensions artifacts from this workflow
         id: download-extensions
@@ -163,7 +163,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extensions
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download managers artifacts from this workflow
         id: download-managers
@@ -171,7 +171,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: managers
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this push,
       # download artifacts from the last successful workflow.
@@ -181,7 +181,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.wrapping-artifact-id }}
 
@@ -190,7 +190,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -199,7 +199,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.maven-artifact-id }}
 
@@ -208,7 +208,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.framework-artifact-id }}
 
@@ -217,7 +217,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extensions
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.extensions-artifact-id }}
 
@@ -226,7 +226,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: managers
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.managers-artifact-id }}
         
@@ -281,7 +281,7 @@ jobs:
       # All other module's artifacts were placed in the source repo previously in the workflow.
       - name: Copy source repo into release repo
         run: |
-          cp -R ${{ github.workspace }}/modules/artifacts/dev/galasa/* ${{ github.workspace }}/modules/obr/repo/dev/galasa
+          cp -R ${{ github.workspace }}/modules/artifacts/* ${{ github.workspace }}/modules/obr/repo
 
       - name: Add githashes of each module to OBR image
         run: |
@@ -403,7 +403,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -411,7 +411,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -419,7 +419,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download framework artifacts from this workflow
         id: download-framework
@@ -427,7 +427,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download extensions artifacts from this workflow
         id: download-extensions
@@ -435,7 +435,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extensions
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download managers artifacts from this workflow
         id: download-managers
@@ -443,7 +443,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: managers
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this push,
       # download artifacts from the last successful workflow.
@@ -453,7 +453,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.wrapping-artifact-id }}
 
@@ -462,7 +462,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -471,7 +471,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.maven-artifact-id }}
 
@@ -480,7 +480,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.framework-artifact-id }}
 
@@ -489,7 +489,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extensions
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.extensions-artifact-id }}
 
@@ -498,7 +498,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: managers
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.managers-artifact-id }}
         
@@ -648,7 +648,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -656,7 +656,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -664,7 +664,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download framework artifacts from this workflow
         id: download-framework
@@ -672,7 +672,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download extensions artifacts from this workflow
         id: download-extensions
@@ -680,7 +680,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extensions
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download managers artifacts from this workflow
         id: download-managers
@@ -688,7 +688,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: managers
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download obr artifacts
         id: download-obr
@@ -696,7 +696,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: obr
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this push,
       # download artifacts from the last successful workflow.
@@ -706,7 +706,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.wrapping-artifact-id }}
 
@@ -715,7 +715,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -724,7 +724,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.maven-artifact-id }}
 
@@ -733,7 +733,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.framework-artifact-id }}
 
@@ -742,7 +742,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extensions
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.extensions-artifact-id }}
 
@@ -751,7 +751,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: managers
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.managers-artifact-id }}
         

--- a/overlays/.github/workflows/pr-buildutils.yaml
+++ b/overlays/.github/workflows/pr-buildutils.yaml
@@ -1,0 +1,91 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Buildutils PR Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+
+env:
+  BRANCH: ${{ github.event.number }}
+
+jobs:
+
+  log-unchanged:
+    name: Buildutils is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The buildutils module is unchanged"
+
+  build-upload-galasabld:
+    name: Build galasabld
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup up Go
+        uses: actions/setup-go@v5
+        with: 
+          go-version: 1.22
+      
+      - name: Build galasabld using the Makefile
+        working-directory: modules/buildutils
+        run: |
+          make all 
+      
+      - name: Build and test galasabld image
+        working-directory: modules/buildutils
+        run: |
+          docker build -t galasabld:${{ env.BRANCH }} --build-arg platform=linux-amd64 -f dockerfiles/galasabld/dockerfile.galasabld .
+          docker run --rm galasabld:${{ env.BRANCH }}
+        
+      - name: Upload galasabld executables
+        uses: actions/upload-artifact@v4
+        with:
+          name: galasabld
+          path: modules/buildutils/bin
+  
+  build-upload-openapi2beans:
+    name: Build openapi2beans
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+  
+      - name: Setup up Go
+        uses: actions/setup-go@v5
+        with: 
+          go-version: 1.22
+              
+      - name: Build and test openapi2beans using the Makefile
+        working-directory: modules/buildutils
+        run: |
+          make all -C openapi2beans
+              
+      - name: Build and test openapi2beans image
+        working-directory: modules/buildutils
+        run: |
+          docker build -t openapi2beans:${{ env.BRANCH }} --build-arg platform=linux-x86_64 -f dockerfiles/openapi2beans/dockerfile.openapi2beans .
+          docker run --rm openapi2beans:${{ env.BRANCH }} 
+      
+      - name: Upload openapi2beans executables
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi2beans
+          path: modules/buildutils/openapi2beans/bin

--- a/overlays/.github/workflows/pr-extensions.yaml
+++ b/overlays/.github/workflows/pr-extensions.yaml
@@ -1,0 +1,153 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Extensions PR Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      wrapping-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
+        required: true
+        type: string
+      gradle-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
+        required: true
+        type: string
+      maven-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
+        required: true
+        type: string
+      framework-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the framework module'
+        required: true
+        type: string
+
+jobs:
+
+  log-unchanged:
+    name: Extensions is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The extensions module is unchanged"
+
+  build-extensions:
+    name: Build Extensions source code
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Setup JDK 
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+          cache-disabled: true
+
+      # For any modules that were changed in this PR,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this PR,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.wrapping-artifact-id }}
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.framework-artifact-id }}
+
+      - name: Build Extensions source code with gradle
+        working-directory: modules/extensions
+        run: |
+          gradle -b galasa-extensions-parent/build.gradle check publish --info \
+          --no-daemon --console plain \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/modules/extensions/repo
+
+      - name: Upload extensions artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: extensions
+          path: modules/extensions/repo/dev/galasa
+          retention-days: 7

--- a/overlays/.github/workflows/pr-extensions.yaml
+++ b/overlays/.github/workflows/pr-extensions.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -79,7 +79,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -87,7 +87,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download framework artifacts from this workflow
         id: download-framework
@@ -95,7 +95,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
@@ -105,7 +105,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.wrapping-artifact-id }}
 
@@ -114,7 +114,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -123,7 +123,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.maven-artifact-id }}
 
@@ -132,7 +132,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.framework-artifact-id }}
 
@@ -149,5 +149,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: extensions
-          path: modules/extensions/repo/dev/galasa
+          path: modules/extensions/repo
           retention-days: 7

--- a/overlays/.github/workflows/pr-framework.yaml
+++ b/overlays/.github/workflows/pr-framework.yaml
@@ -12,6 +12,10 @@ on:
         description: 'True if this module has been changed and should be rebuilt'
         required: true
         type: string
+      openapi2beans-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for openapi2beans'
+        required: true
+        type: string
       wrapping-artifact-id:
         description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
         required: true
@@ -61,16 +65,16 @@ jobs:
           gradle-version: 8.9
           cache-disabled: true
       
-      - name: Build servlet beans with openapi2beans
-        env:
-          YAML_LOCATION: "modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml"
-          OUTPUT_LOCATION: "modules/framework/galasa-parent/dev.galasa.framework.api.beans/src/main/java"
-          PACKAGE: "dev.galasa.framework.api.beans.generated"
-        run: |
-          docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/openapi2beans:main generate --yaml var/workspace/${{ env.YAML_LOCATION }} --output var/workspace/${{ env.OUTPUT_LOCATION }} --package ${{ env.PACKAGE }}
-
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.
+
+      - name: Download openapi2beans artifacts from this workflow
+        id: download-openapi2beans
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: openapi2beans
+          path: modules/artifacts/openapi2beans
 
       - name: Download wrapping artifacts from this workflow
         id: download-wrapping
@@ -99,6 +103,15 @@ jobs:
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
 
+      - name: Download openapi2beans artifacts from last successful workflow
+        if: ${{ steps.download-openapi2beans.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: openapi2beans
+          path: modules/artifacts/openapi2beans
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.openapi2beans-artifact-id }}
+
       - name: Download wrapping artifacts from last successful workflow
         if: ${{ steps.download-wrapping.outcome == 'failure' }}
         uses: actions/download-artifact@v4
@@ -125,6 +138,25 @@ jobs:
           path: modules/artifacts/dev/galasa
           github-token: ${{ github.token }}
           run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Build servlet beans with openapi2beans
+        if: ${{ steps.download-openapi2beans.outcome == 'success' }}
+        env:
+          YAML_LOCATION: "modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml"
+          OUTPUT_LOCATION: "modules/framework/galasa-parent/dev.galasa.framework.api.beans/src/main/java"
+          PACKAGE: "dev.galasa.framework.api.beans.generated"
+        run: |
+          chmod +x ./modules/artifacts/openapi2beans/openapi2beans-linux-x86_64
+          ./modules/artifacts/openapi2beans/openapi2beans-linux-x86_64 generate --yaml ${{ github.workspace }}/${{ env.YAML_LOCATION }} --output ${{ github.workspace }}/${{ env.OUTPUT_LOCATION }} --package ${{ env.PACKAGE }}
+      
+      - name: Build servlet beans with openapi2beans
+        if: ${{ steps.download-openapi2beans.outcome == 'failure' }}
+        env:
+          YAML_LOCATION: "modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml"
+          OUTPUT_LOCATION: "modules/framework/galasa-parent/dev.galasa.framework.api.beans/src/main/java"
+          PACKAGE: "dev.galasa.framework.api.beans.generated"
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/openapi2beans:main generate --yaml var/workspace/${{ env.YAML_LOCATION }} --output var/workspace/${{ env.OUTPUT_LOCATION }} --package ${{ env.PACKAGE }}
 
       - name: Build Framework source code
         working-directory: modules/framework

--- a/overlays/.github/workflows/pr-framework.yaml
+++ b/overlays/.github/workflows/pr-framework.yaml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -90,7 +90,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -98,7 +98,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
@@ -117,7 +117,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.wrapping-artifact-id }}
 
@@ -126,7 +126,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -135,7 +135,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.maven-artifact-id }}
 
@@ -181,7 +181,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: framework
-          path: modules/framework/repo/dev/galasa
+          path: modules/framework/repo
           retention-days: 7
 
   build-rest-api-documentation:

--- a/overlays/.github/workflows/pr-framework.yaml
+++ b/overlays/.github/workflows/pr-framework.yaml
@@ -1,0 +1,186 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Framework PR Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      wrapping-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
+        required: true
+        type: string
+      gradle-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
+        required: true
+        type: string
+      maven-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
+        required: true
+        type: string
+
+env:
+  NAMESPACE: ${{ github.repository_owner }}
+  
+jobs:
+
+  log-unchanged:
+    name: Framework is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The framework module is unchanged"
+
+  build-framework:
+    name: Build Framework using openapi2beans and gradle
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Setup JDK 
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+        
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+          cache-disabled: true
+      
+      - name: Build servlet beans with openapi2beans
+        env:
+          YAML_LOCATION: "modules/framework/galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml"
+          OUTPUT_LOCATION: "modules/framework/galasa-parent/dev.galasa.framework.api.beans/src/main/java"
+          PACKAGE: "dev.galasa.framework.api.beans.generated"
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/${{ env.NAMESPACE }}/openapi2beans:main generate --yaml var/workspace/${{ env.YAML_LOCATION }} --output var/workspace/${{ env.OUTPUT_LOCATION }} --package ${{ env.PACKAGE }}
+
+      # For any modules that were changed in this PR,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this PR,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.wrapping-artifact-id }}
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Build Framework source code
+        working-directory: modules/framework
+        run: |
+          gradle -b galasa-parent/build.gradle check publish --info \
+          --no-daemon --console plain \
+          -Dorg.gradle.jvmargs=-Xmx5120M \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/modules/framework/repo
+      
+      - name: Upload Jacoco Reports as artifact
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: framework-unit-tests
+          path: modules/framework/galasa-parent/**/build/reports/**/*.html
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload framework artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: framework
+          path: modules/framework/repo/dev/galasa
+          retention-days: 7
+
+  build-rest-api-documentation:
+    name: Build REST API documentation using openapi2beans and gradle
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Setup JDK 
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+      
+      - name: Install Swagger CLI
+        working-directory: modules/framework
+        run: |
+          wget https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/3.0.41/swagger-codegen-cli-3.0.41.jar -O swagger-codegen-cli.jar
+      
+      - name: Generate Swagger docs
+        working-directory: modules/framework
+        run: |
+          java -jar swagger-codegen-cli.jar generate -i galasa-parent/dev.galasa.framework.api.openapi/src/main/resources/openapi.yaml -l html2 -o docs/generated/galasaapi
+
+      - name: Build Restapidoc image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/framework
+          file: modules/framework/dockerfiles/dockerfile.restapidocsite
+          load: true
+          tags: restapidoc-site:test

--- a/overlays/.github/workflows/pr-gradle.yaml
+++ b/overlays/.github/workflows/pr-gradle.yaml
@@ -1,0 +1,63 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Gradle PR Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+
+jobs:
+
+  log-unchanged:
+    name: Gradle is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The gradle module is unchanged"
+
+  build-gradle:
+    name: Build Gradle source code and Docker image
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup JDK 
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+          cache-disabled: true
+
+      - name: Build Gradle source code
+        working-directory: modules/gradle
+        run: |
+          gradle check publish --info \
+          --no-daemon --console plain \
+          -PsourceMaven=https://repo.maven.apache.org/maven2/ \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/modules/gradle/repo
+
+      - name: Upload gradle artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: gradle
+          path: modules/gradle/repo/dev/galasa
+          retention-days: 7

--- a/overlays/.github/workflows/pr-gradle.yaml
+++ b/overlays/.github/workflows/pr-gradle.yaml
@@ -59,5 +59,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: gradle
-          path: modules/gradle/repo/dev/galasa
+          path: modules/gradle/repo
           retention-days: 7

--- a/overlays/.github/workflows/pr-managers.yaml
+++ b/overlays/.github/workflows/pr-managers.yaml
@@ -1,0 +1,172 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Managers PR Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      wrapping-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
+        required: true
+        type: string
+      gradle-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
+        required: true
+        type: string
+      maven-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
+        required: true
+        type: string
+      framework-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the framework module'
+        required: true
+        type: string
+
+jobs:
+
+  log-unchanged:
+    name: Managers is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The managers module is unchanged"
+
+  build-managers:
+    name: Build Managers source code and Docker image
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Setup JDK 
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
+        with:
+          gradle-version: 8.9
+          cache-disabled: true
+
+      # For any modules that were changed in this PR,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this PR,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.wrapping-artifact-id }}
+  
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.framework-artifact-id }}
+      
+      - name: Build Managers source code
+        working-directory: modules/managers
+        run: |
+          set -o pipefail
+          gradle -b galasa-managers-parent/build.gradle check publish --info \
+          --no-daemon --console plain \
+          -Dorg.gradle.jvmargs=-Xmx4096M \
+          -PsourceMaven=${{ github.workspace }}/modules/artifacts \
+          -PcentralMaven=https://repo.maven.apache.org/maven2/ \
+          -PtargetMaven=${{ github.workspace }}/modules/managers/repo 2>&1 | tee build.log
+
+      - name: Upload Gradle Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: managers-gradle-build-log
+          path: modules/managers/build.log
+          retention-days: 7
+            
+      - name: Upload Jacoco Report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: managers-jacoco-report
+          path: modules/managers/galasa-managers-parent/**/**/build/reports/**/*.html
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload managers artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: managers
+          path: modules/managers/repo/dev/galasa
+          retention-days: 7

--- a/overlays/.github/workflows/pr-managers.yaml
+++ b/overlays/.github/workflows/pr-managers.yaml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -79,7 +79,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -87,7 +87,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download framework artifacts from this workflow
         id: download-framework
@@ -95,7 +95,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
@@ -105,7 +105,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.wrapping-artifact-id }}
   
@@ -114,7 +114,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -123,7 +123,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.maven-artifact-id }}
 
@@ -132,7 +132,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.framework-artifact-id }}
       
@@ -168,5 +168,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: managers
-          path: modules/managers/repo/dev/galasa
+          path: modules/managers/repo
           retention-days: 7

--- a/overlays/.github/workflows/pr-maven.yaml
+++ b/overlays/.github/workflows/pr-maven.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
@@ -103,7 +103,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.gradle-artifact-id }}
       
@@ -122,5 +122,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: maven
-          path: modules/maven/repo/dev/galasa
+          path: modules/maven/repo
           retention-days: 7

--- a/overlays/.github/workflows/pr-maven.yaml
+++ b/overlays/.github/workflows/pr-maven.yaml
@@ -1,0 +1,126 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Maven PR Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      gradle-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
+        required: true
+        type: string
+
+jobs:
+
+  log-unchanged:
+    name: Maven is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The maven module is unchanged"
+
+  build-maven:
+    name: Build Maven source code and Docker image
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+      
+      # Copy secrets into files to use in workflow
+      - name: Make secrets directory
+        run : |
+          mkdir /home/runner/work/secrets
+
+      - name: Copy settings.xml
+        env:
+          MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+        run : |
+          echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+
+      - name: Copy GPG passphrase
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run : |
+          echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+
+      - name: Copy GPG key
+        env:
+          GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+        run : |
+          echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+            
+        # Set up Maven GPG directory
+      - name: Make GPG home directory
+        run: |
+          mkdir /home/runner/work/gpg
+        
+      - name: Change directory permissions
+        run: |
+          chmod '700' /home/runner/work/gpg
+  
+      - name: Import GPG
+        run: |
+          gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+        
+      - name: Copy custom settings.xml
+        run: |
+          cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+
+      # For any modules that were changed in this PR,
+      # download their artifacts from this workflow run.
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this PR,
+      # download artifacts from the last successful workflow.
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.gradle-artifact-id }}
+      
+      - name: Building Maven source code
+        working-directory: modules/maven
+        run: |
+          mvn -f galasa-maven-plugin/pom.xml deploy -X \
+          -Dgpg.skip=true \
+          -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/modules/maven/repo \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml
+
+      - name: Upload maven artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven
+          path: modules/maven/repo/dev/galasa
+          retention-days: 7

--- a/overlays/.github/workflows/pr-obr.yaml
+++ b/overlays/.github/workflows/pr-obr.yaml
@@ -392,10 +392,6 @@ jobs:
       - name: Copy custom settings.xml
         run: |
           cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
-          
-      - name: Display Galasa Javadoc pom.xml 
-        run: |
-          cat modules/obr/javadocs/pom.xml
 
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.
@@ -532,7 +528,7 @@ jobs:
         if: ${{ steps.download-galasabld.outcome == 'failure' }}
         run: |
           docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/javadocs/pom.template --output /var/root/obr/javadocs/pom.xml --javadoc
-            
+
       - name: Display Galasa Javadoc pom.xml 
         run: |
           cat modules/obr/javadocs/pom.xml

--- a/overlays/.github/workflows/pr-obr.yaml
+++ b/overlays/.github/workflows/pr-obr.yaml
@@ -272,12 +272,19 @@ jobs:
           path: modules/obr/galasa-obr-build.log
           retention-days: 7
 
+      # The obr-maven-artefacts image which is built from the release repo's directory
+      # needs not only the obr module's artifacts but all other module's artifacts.
+      # All other module's artifacts were placed in the source repo previously in the workflow.
+      - name: Copy source repo into release repo
+        run: |
+          cp -R ${{ github.workspace }}/modules/artifacts ${{ github.workspace }}/modules/obr/repo
+
       - name: Upload obr artifacts
         uses: actions/upload-artifact@v4
         with:
-            name: obr
-            path: modules/obr/repo/dev/galasa
-            retention-days: 7
+          name: obr
+          path: modules/obr/repo
+          retention-days: 7
       
       - name: Build OBR image for testing
         uses: docker/build-push-action@v5

--- a/overlays/.github/workflows/pr-obr.yaml
+++ b/overlays/.github/workflows/pr-obr.yaml
@@ -12,6 +12,10 @@ on:
         description: 'True if this module has been changed and should be rebuilt'
         required: true
         type: string
+      galasabld-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for galasabld'
+        required: true
+        type: string
       wrapping-artifact-id:
         description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
         required: true
@@ -107,17 +111,17 @@ jobs:
       - name: Copy custom settings.xml
         run: |
             cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
-      
-      - name:  Generate Galasa BOM
-        run: |
-          docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/galasa-bom/pom.template --output /var/root/obr/galasa-bom/pom.xml --bom
-          
-      - name: Display Galasa BOM pom.xml
-        run: |
-          cat modules/obr/galasa-bom/pom.xml
 
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.
+
+      - name: Download galasabld artifacts from this workflow
+        id: download-galasabld
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: galasabld
+          path: modules/artifacts/galasabld
 
       - name: Download wrapping artifacts from this workflow
         id: download-wrapping
@@ -169,6 +173,15 @@ jobs:
 
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
+
+      - name: Download galasabld artifacts from last successful workflow
+        if: ${{ steps.download-galasabld.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: galasabld
+          path: modules/artifacts/galasabld
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.galasabld-artifact-id }}
 
       - name: Download wrapping artifacts from last successful workflow
         if: ${{ steps.download-wrapping.outcome == 'failure' }}
@@ -223,6 +236,21 @@ jobs:
             path: modules/artifacts/dev/galasa
             github-token: ${{ github.token }}
             run-id: ${{ inputs.managers-artifact-id }}
+
+      - name:  Generate Galasa BOM
+        if: ${{ steps.download-galasabld.outcome == 'success' }}
+        run: |
+          chmod +x ./modules/artifacts/galasabld/galasabld-linux-amd64
+          ./modules/artifacts/galasabld/galasabld-linux-amd64 template --releaseMetadata ${{ github.workspace }}/modules/framework/release.yaml --releaseMetadata ${{ github.workspace }}/modules/extensions/release.yaml --releaseMetadata ${{ github.workspace }}/modules/managers/release.yaml --releaseMetadata ${{ github.workspace }}/modules/obr/release.yaml --template ${{ github.workspace }}/modules/obr/galasa-bom/pom.template --output ${{ github.workspace }}/modules/obr/galasa-bom/pom.xml --bom
+      
+      - name:  Generate Galasa BOM
+        if: ${{ steps.download-galasabld.outcome == 'failure' }}
+        run: |
+          docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/galasa-bom/pom.template --output /var/root/obr/galasa-bom/pom.xml --bom
+          
+      - name: Display Galasa BOM pom.xml
+        run: |
+          cat modules/obr/galasa-bom/pom.xml
         
       - name: Build Galasa BOM with maven
         working-directory: modules/obr
@@ -243,8 +271,15 @@ jobs:
           name: galasa-bom-build-log
           path: modules/obr/galasa-bom-build.log
           retention-days: 7
+
+      - name:  Generate Galasa OBR
+        if: ${{ steps.download-galasabld.outcome == 'success' }}
+        run: |
+          chmod +x ./modules/artifacts/galasabld/galasabld-linux-amd64
+          ./modules/artifacts/galasabld/galasabld-linux-amd64 template --releaseMetadata ${{ github.workspace }}/modules/framework/release.yaml --releaseMetadata ${{ github.workspace }}/modules/extensions/release.yaml --releaseMetadata ${{ github.workspace }}/modules/managers/release.yaml --releaseMetadata ${{ github.workspace }}/modules/obr/release.yaml --template ${{ github.workspace }}/modules/obr/dev.galasa.uber.obr/pom.template --output ${{ github.workspace }}/modules/obr/dev.galasa.uber.obr/pom.xml --obr
       
       - name:  Generate Galasa OBR
+        if: ${{ steps.download-galasabld.outcome == 'failure' }}
         run: |
           docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/dev.galasa.uber.obr/pom.template --output /var/root/obr/dev.galasa.uber.obr/pom.xml --obr
           
@@ -277,7 +312,18 @@ jobs:
       # All other module's artifacts were placed in the source repo previously in the workflow.
       - name: Copy source repo into release repo
         run: |
-          cp -R ${{ github.workspace }}/modules/artifacts ${{ github.workspace }}/modules/obr/repo
+          cp -R ${{ github.workspace }}/modules/artifacts/dev/galasa/* ${{ github.workspace }}/modules/obr/repo/dev/galasa
+
+      - name: Add githashes of each module to OBR image
+        run: |
+          echo $(git log -1 --pretty=format:"%H" -- "modules/buildutils") > modules/obr/buildutils.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/wrapping") > modules/obr/wrapping.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/gradle") > modules/obr/gradle.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/maven") > modules/obr/maven.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/framework") > modules/obr/framework.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/extensions") > modules/obr/extensions.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/managers") > modules/obr/managers.githash
+          echo $(git log -1 --pretty=format:"%H" -- "modules/obr") > modules/obr/obr.githash
 
       - name: Upload obr artifacts
         uses: actions/upload-artifact@v4
@@ -347,16 +393,20 @@ jobs:
         run: |
           cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
           
-      - name: Build Galasa Javadoc
-        run: |
-            docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/javadocs/pom.template --output /var/root/obr/javadocs/pom.xml --javadoc
-            
       - name: Display Galasa Javadoc pom.xml 
         run: |
           cat modules/obr/javadocs/pom.xml
 
       # For any modules that were changed in this PR,
       # download their artifacts from this workflow run.
+
+      - name: Download galasabld artifacts from this workflow
+        id: download-galasabld
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: galasabld
+          path: modules/artifacts/galasabld
 
       - name: Download wrapping artifacts from this workflow
         id: download-wrapping
@@ -408,6 +458,15 @@ jobs:
 
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
+
+      - name: Download galasabld artifacts from last successful workflow
+        if: ${{ steps.download-galasabld.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: galasabld
+          path: modules/artifacts/galasabld
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.galasabld-artifact-id }}
 
       - name: Download wrapping artifacts from last successful workflow
         if: ${{ steps.download-wrapping.outcome == 'failure' }}
@@ -462,6 +521,21 @@ jobs:
             path: modules/artifacts/dev/galasa
             github-token: ${{ github.token }}
             run-id: ${{ inputs.managers-artifact-id }}
+
+      - name: Build Galasa Javadoc
+        if: ${{ steps.download-galasabld.outcome == 'success' }}
+        run: |
+          chmod +x ./modules/artifacts/galasabld/galasabld-linux-amd64
+          ./modules/artifacts/galasabld/galasabld-linux-amd64 template --releaseMetadata ${{ github.workspace }}/modules/framework/release.yaml --releaseMetadata ${{ github.workspace }}/modules/extensions/release.yaml --releaseMetadata ${{ github.workspace }}/modules/managers/release.yaml --releaseMetadata ${{ github.workspace }}/modules/obr/release.yaml --template ${{ github.workspace }}/modules/obr/javadocs/pom.template --output ${{ github.workspace }}/modules/obr/javadocs/pom.xml --javadoc
+            
+      - name: Build Galasa Javadoc
+        if: ${{ steps.download-galasabld.outcome == 'failure' }}
+        run: |
+          docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/javadocs/pom.template --output /var/root/obr/javadocs/pom.xml --javadoc
+            
+      - name: Display Galasa Javadoc pom.xml 
+        run: |
+          cat modules/obr/javadocs/pom.xml
         
       - name: Build javadoc site using maven
         working-directory: modules/obr/javadocs

--- a/overlays/.github/workflows/pr-obr.yaml
+++ b/overlays/.github/workflows/pr-obr.yaml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -137,7 +137,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -145,7 +145,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download framework artifacts from this workflow
         id: download-framework
@@ -153,7 +153,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download extensions artifacts from this workflow
         id: download-extensions
@@ -161,7 +161,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extensions
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download managers artifacts from this workflow
         id: download-managers
@@ -169,7 +169,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: managers
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
@@ -188,7 +188,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: wrapping
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.wrapping-artifact-id }}
 
@@ -197,7 +197,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: gradle
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -206,7 +206,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: maven
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.maven-artifact-id }}
 
@@ -215,7 +215,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: framework
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.framework-artifact-id }}
 
@@ -224,7 +224,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extensions
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.extensions-artifact-id }}
 
@@ -233,7 +233,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: managers
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.managers-artifact-id }}
 
@@ -312,7 +312,7 @@ jobs:
       # All other module's artifacts were placed in the source repo previously in the workflow.
       - name: Copy source repo into release repo
         run: |
-          cp -R ${{ github.workspace }}/modules/artifacts/dev/galasa/* ${{ github.workspace }}/modules/obr/repo/dev/galasa
+          cp -R ${{ github.workspace }}/modules/artifacts/* ${{ github.workspace }}/modules/obr/repo
 
       - name: Add githashes of each module to OBR image
         run: |
@@ -410,7 +410,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: wrapping
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download gradle artifacts from this workflow
         id: download-gradle
@@ -418,7 +418,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: gradle
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download maven artifacts from this workflow
         id: download-maven
@@ -426,7 +426,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: maven
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download framework artifacts from this workflow
         id: download-framework
@@ -434,7 +434,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: framework
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download extensions artifacts from this workflow
         id: download-extensions
@@ -442,7 +442,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extensions
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
 
       - name: Download managers artifacts from this workflow
         id: download-managers
@@ -450,7 +450,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: managers
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
 
       # For any modules that weren't changed in this PR,
       # download artifacts from the last successful workflow.
@@ -469,7 +469,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: wrapping
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.wrapping-artifact-id }}
 
@@ -478,7 +478,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: gradle
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.gradle-artifact-id }}
 
@@ -487,7 +487,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: maven
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.maven-artifact-id }}
 
@@ -496,7 +496,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: framework
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.framework-artifact-id }}
 
@@ -505,7 +505,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: extensions
-          path: modules/artifacts/dev/galasa
+          path: modules/artifacts
           github-token: ${{ github.token }}
           run-id: ${{ inputs.extensions-artifact-id }}
 
@@ -514,7 +514,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
             name: managers
-            path: modules/artifacts/dev/galasa
+            path: modules/artifacts
             github-token: ${{ github.token }}
             run-id: ${{ inputs.managers-artifact-id }}
 

--- a/overlays/.github/workflows/pr-obr.yaml
+++ b/overlays/.github/workflows/pr-obr.yaml
@@ -1,0 +1,497 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: OBR PR Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      wrapping-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the wrapping module'
+        required: true
+        type: string
+      gradle-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the gradle module'
+        required: true
+        type: string
+      maven-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the maven module'
+        required: true
+        type: string
+      framework-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the framework module'
+        required: true
+        type: string
+      extensions-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the extensions module'
+        required: true
+        type: string
+      managers-artifact-id:
+        description: 'The Workflow Run ID of the last workflow containing artifacts for the managers module'
+        required: true
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+
+  log-unchanged:
+    name: OBR is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The obr module is unchanged"
+
+  build-obr:
+    name: Build OBR using galasabld image and maven
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+  
+      - name: Print githash
+        working-directory: modules/obr
+        run: |
+          echo $GITHUB_SHA > ./obr.githash
+
+      - name: Make secrets directory
+        run : |
+            mkdir /home/runner/work/secrets
+
+      - name: Copy settings.xml
+        env:
+            MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+        run : |
+            echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+      
+      - name: Copy GPG passphrase
+        env:
+            GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run : |
+            echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+      
+      - name: Copy GPG key
+        env:
+            GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+        run : |
+            echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+            
+      - name: Make GPG home directory and change permissions
+        run: |
+            mkdir /home/runner/work/gpg
+            chmod '700' /home/runner/work/gpg
+        
+      - name: Import GPG
+        run: |
+            gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+        
+      - name: Copy custom settings.xml
+        run: |
+            cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+      
+      - name:  Generate Galasa BOM
+        run: |
+          docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/galasa-bom/pom.template --output /var/root/obr/galasa-bom/pom.xml --bom
+          
+      - name: Display Galasa BOM pom.xml
+        run: |
+          cat modules/obr/galasa-bom/pom.xml
+
+      # For any modules that were changed in this PR,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+
+      - name: Download extensions artifacts from this workflow
+        id: download-extensions
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts/dev/galasa
+
+      - name: Download managers artifacts from this workflow
+        id: download-managers
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: managers
+          path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this PR,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: wrapping
+            path: modules/artifacts/dev/galasa
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.wrapping-artifact-id }}
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: gradle
+            path: modules/artifacts/dev/galasa
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: maven
+            path: modules/artifacts/dev/galasa
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: framework
+            path: modules/artifacts/dev/galasa
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.framework-artifact-id }}
+
+      - name: Download extensions artifacts from last successful workflow
+        if: ${{ steps.download-extensions.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.extensions-artifact-id }}
+
+      - name: Download managers artifacts from last successful workflow
+        if: ${{ steps.download-managers.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: managers
+            path: modules/artifacts/dev/galasa
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.managers-artifact-id }}
+        
+      - name: Build Galasa BOM with maven
+        working-directory: modules/obr
+        run: |
+          set -o pipefail
+          mvn -f galasa-bom/pom.xml deploy -X \
+          -Dgpg.skip=true \
+          -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/repo \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-bom-build.log
+        
+      - name: Upload Galasa BOM Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: galasa-bom-build-log
+          path: modules/obr/galasa-bom-build.log
+          retention-days: 7
+      
+      - name:  Generate Galasa OBR
+        run: |
+          docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/dev.galasa.uber.obr/pom.template --output /var/root/obr/dev.galasa.uber.obr/pom.xml --obr
+          
+      - name: Display Galasa OBR pom.xml
+        run: |
+          cat modules/obr/dev.galasa.uber.obr/pom.xml
+        
+      - name: Build Galasa OBR with maven
+        working-directory: modules/obr
+        run: |
+          set -o pipefail
+          mvn -f dev.galasa.uber.obr/pom.xml deploy -X \
+          -Dgpg.skip=true \
+          -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/repo \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee galasa-obr-build.log
+
+      - name: Upload Galasa OBR Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: galasa-obr-build-log
+          path: modules/obr/galasa-obr-build.log
+          retention-days: 7
+
+      - name: Upload obr artifacts
+        uses: actions/upload-artifact@v4
+        with:
+            name: obr
+            path: modules/obr/repo/dev/galasa
+            retention-days: 7
+      
+      - name: Build OBR image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/obr
+          file: modules/obr/dockerfiles/dockerfile.obr
+          load: true
+          tags: obr-maven-artefacts:test
+          build-args: |
+            dockerRepository=${{ env.REGISTRY }}
+            tag=main
+
+  build-obr-javadocs:
+    name: Build OBR javadocs using galasabld image and maven
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+      
+      - name: Make secrets directory
+        run : |
+            mkdir /home/runner/work/secrets
+
+      - name: Copy settings.xml 
+        env:
+          MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+        run : |
+          echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+
+      - name: Copy GPG passphrase
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run : |
+          echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+
+      - name: Copy GPG key
+        env:
+          GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+        run : |
+          echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+          
+      - name: Make GPG home directory and change permissions
+        run: |
+          mkdir /home/runner/work/gpg
+          chmod '700' /home/runner/work/gpg
+
+      - name: Import GPG
+        run: |
+          gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+      
+      - name: Copy custom settings.xml
+        run: |
+          cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+          
+      - name: Build Galasa Javadoc
+        run: |
+            docker run --rm -v ${{ github.workspace }}/modules:/var/root/ ghcr.io/${{ env.NAMESPACE }}/galasabld-amd64:main template --releaseMetadata var/root/framework/release.yaml --releaseMetadata /var/root/extensions/release.yaml --releaseMetadata /var/root/managers/release.yaml --releaseMetadata /var/root/obr/release.yaml --template /var/root/obr/javadocs/pom.template --output /var/root/obr/javadocs/pom.xml --javadoc
+            
+      - name: Display Galasa Javadoc pom.xml 
+        run: |
+          cat modules/obr/javadocs/pom.xml
+
+      # For any modules that were changed in this PR,
+      # download their artifacts from this workflow run.
+
+      - name: Download wrapping artifacts from this workflow
+        id: download-wrapping
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: wrapping
+          path: modules/artifacts/dev/galasa
+
+      - name: Download gradle artifacts from this workflow
+        id: download-gradle
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gradle
+          path: modules/artifacts/dev/galasa
+
+      - name: Download maven artifacts from this workflow
+        id: download-maven
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: maven
+          path: modules/artifacts/dev/galasa
+
+      - name: Download framework artifacts from this workflow
+        id: download-framework
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: framework
+          path: modules/artifacts/dev/galasa
+
+      - name: Download extensions artifacts from this workflow
+        id: download-extensions
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts/dev/galasa
+
+      - name: Download managers artifacts from this workflow
+        id: download-managers
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+            name: managers
+            path: modules/artifacts/dev/galasa
+
+      # For any modules that weren't changed in this PR,
+      # download artifacts from the last successful workflow.
+
+      - name: Download wrapping artifacts from last successful workflow
+        if: ${{ steps.download-wrapping.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: wrapping
+            path: modules/artifacts/dev/galasa
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.wrapping-artifact-id }}
+
+      - name: Download gradle artifacts from last successful workflow
+        if: ${{ steps.download-gradle.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: gradle
+            path: modules/artifacts/dev/galasa
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.gradle-artifact-id }}
+
+      - name: Download maven artifacts from last successful workflow
+        if: ${{ steps.download-maven.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: maven
+            path: modules/artifacts/dev/galasa
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.maven-artifact-id }}
+
+      - name: Download framework artifacts from last successful workflow
+        if: ${{ steps.download-framework.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: framework
+            path: modules/artifacts/dev/galasa
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.framework-artifact-id }}
+
+      - name: Download extensions artifacts from last successful workflow
+        if: ${{ steps.download-extensions.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: extensions
+          path: modules/artifacts/dev/galasa
+          github-token: ${{ github.token }}
+          run-id: ${{ inputs.extensions-artifact-id }}
+
+      - name: Download managers artifacts from last successful workflow
+        if: ${{ steps.download-managers.outcome == 'failure' }}
+        uses: actions/download-artifact@v4
+        with:
+            name: managers
+            path: modules/artifacts/dev/galasa
+            github-token: ${{ github.token }}
+            run-id: ${{ inputs.managers-artifact-id }}
+        
+      - name: Build javadoc site using maven
+        working-directory: modules/obr/javadocs
+        run: |
+          set -o pipefail
+          mvn -f pom.xml deploy -X \
+          -Dgpg.skip=true \
+          -Dgalasa.source.repo=file:${{ github.workspace }}/modules/artifacts \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/modules/obr/javadocs/docker/repo \
+          -Dmaven.javadoc.failOnError=false \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
+
+      - name: Upload javadoc site Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: javadoc-site-build-log
+          path: modules/obr/javadocs/build.log
+          retention-days: 7
+      
+      - name: Build Javadoc site image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/obr
+          file: modules/obr/dockerfiles/dockerfile.javadocsite
+          load: true
+          tags: javadoc-site:test
+
+      - name: Build Javadoc Maven repo image for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: modules/obr
+          file: modules/obr/dockerfiles/dockerfile.javadocmavenrepo
+          load: true
+          tags: javadoc-maven-artefacts:test
+          build-args: |
+            dockerRepository=${{ env.REGISTRY }}
+            baseVersion=latest

--- a/overlays/.github/workflows/pr-wrapping.yaml
+++ b/overlays/.github/workflows/pr-wrapping.yaml
@@ -1,0 +1,101 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Wrapping PR Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+
+jobs:
+
+  log-unchanged:
+    name: Wrapping is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The wrapping module is unchanged"
+
+  build-wrapping:
+    name: Build Wrapping source code and Docker image
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      # The githash is added to the development Maven registry to show what commit level it contains
+      - name: Print githash
+        run: |
+          echo $GITHUB_SHA > ./wrapping.githash
+
+      # Copy secrets into files to use in workflow
+      - name: Make secrets directory
+        run : |
+          mkdir /home/runner/work/secrets
+      - name: Copy settings.xml
+        env:
+          MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+        run : |
+          echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+      - name: Copy GPG passphrase
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run : |
+          echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+      - name: Copy GPG key
+        env:
+          GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+        run : |
+          echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+          
+      # Set up Maven GPG directory
+      - name: Make GPG home directory
+        run: |
+          mkdir /home/runner/work/gpg
+      
+      - name: Change directory permissions
+        run: |
+          chmod '700' /home/runner/work/gpg
+
+      - name: Import GPG
+        run: |
+          gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+      
+      - name: Copy custom settings.xml
+        run: |
+          cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+      
+      - name: Building Wrapping source code
+        working-directory: modules/wrapping
+        run: |
+          mvn deploy -X \
+          -Dgpg.skip=true \
+          -Dgalasa.source.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/modules/wrapping/repo \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml
+
+      - name: Upload wrapping artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wrapping
+          path: modules/wrapping/repo/dev/galasa
+          retention-days: 7

--- a/overlays/.github/workflows/pr-wrapping.yaml
+++ b/overlays/.github/workflows/pr-wrapping.yaml
@@ -40,11 +40,6 @@ jobs:
           java-version: '17'
           distribution: 'semeru'
 
-      # The githash is added to the development Maven registry to show what commit level it contains
-      - name: Print githash
-        run: |
-          echo $GITHUB_SHA > ./wrapping.githash
-
       # Copy secrets into files to use in workflow
       - name: Make secrets directory
         run : |

--- a/overlays/.github/workflows/pr-wrapping.yaml
+++ b/overlays/.github/workflows/pr-wrapping.yaml
@@ -92,5 +92,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wrapping
-          path: modules/wrapping/repo/dev/galasa
+          path: modules/wrapping/repo
           retention-days: 7

--- a/overlays/.github/workflows/pull-requests.yaml
+++ b/overlays/.github/workflows/pull-requests.yaml
@@ -43,7 +43,8 @@ jobs:
     runs-on: ubuntu-latest
 
     outputs: 
-      buildutils_artifacts_id: ${{ steps.find-artifacts.outputs.buildutils_artifacts_id }}
+      galasabld_artifacts_id: ${{ steps.find-artifacts.outputs.galasabld_artifacts_id }}
+      openapi2beans_artifacts_id: ${{ steps.find-artifacts.outputs.openapi2beans_artifacts_id }}
       wrapping_artifacts_id: ${{ steps.find-artifacts.outputs.wrapping_artifacts_id }}
       gradle_artifacts_id: ${{ steps.find-artifacts.outputs.gradle_artifacts_id }}
       maven_artifacts_id: ${{ steps.find-artifacts.outputs.maven_artifacts_id }}
@@ -103,6 +104,7 @@ jobs:
     secrets: inherit
     with:
       changed: ${{ needs.get-changed-modules.outputs.framework_changed }}
+      openapi2beans-artifact-id: ${{ needs.find-artifacts.outputs.openapi2beans_artifacts_id }}
       wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
       gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
       maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
@@ -138,6 +140,7 @@ jobs:
     secrets: inherit
     with:
       changed: ${{ needs.get-changed-modules.outputs.obr_changed }}
+      galasabld-artifact-id: ${{ needs.find-artifacts.outputs.galasabld_artifacts_id }}
       wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
       gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
       maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}

--- a/overlays/.github/workflows/pull-requests.yaml
+++ b/overlays/.github/workflows/pull-requests.yaml
@@ -1,0 +1,146 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Pull Request Build Orchestrator
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+
+  # Get modules that were changed as part of this Pull Request,
+  # set that as an output of this job to be passed to the next job. 
+  get-changed-modules:
+    name: Get the modules changed in this Pull Request
+    runs-on: ubuntu-latest
+
+    outputs:
+      buildutils_changed: ${{ steps.get-changed-modules.outputs.BUILDUTILS_CHANGED }}
+      wrapping_changed: ${{ steps.get-changed-modules.outputs.WRAPPING_CHANGED }}
+      gradle_changed: ${{ steps.get-changed-modules.outputs.GRADLE_CHANGED }}
+      maven_changed: ${{ steps.get-changed-modules.outputs.MAVEN_CHANGED }}
+      framework_changed: ${{ steps.get-changed-modules.outputs.FRAMEWORK_CHANGED }}
+      extensions_changed: ${{ steps.get-changed-modules.outputs.EXTENSIONS_CHANGED }}
+      managers_changed: ${{ steps.get-changed-modules.outputs.MANAGERS_CHANGED }}
+      obr_changed: ${{ steps.get-changed-modules.outputs.OBR_CHANGED }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Get the modules changed in this Pull Request
+        id: get-changed-modules
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./tools/get-changed-modules-pull-request.sh --pr-number ${{ github.event.number }}
+
+  find-artifacts:
+    name: Get Workflow Run IDs with artifacts to download for each module
+    runs-on: ubuntu-latest
+
+    outputs: 
+      buildutils_artifacts_id: ${{ steps.find-artifacts.outputs.buildutils_artifacts_id }}
+      wrapping_artifacts_id: ${{ steps.find-artifacts.outputs.wrapping_artifacts_id }}
+      gradle_artifacts_id: ${{ steps.find-artifacts.outputs.gradle_artifacts_id }}
+      maven_artifacts_id: ${{ steps.find-artifacts.outputs.maven_artifacts_id }}
+      framework_artifacts_id: ${{ steps.find-artifacts.outputs.framework_artifacts_id }}
+      extensions_artifacts_id: ${{ steps.find-artifacts.outputs.extensions_artifacts_id }}
+      managers_artifacts_id: ${{ steps.find-artifacts.outputs.managers_artifacts_id }}
+      obr_artifacts_id: ${{ steps.find-artifacts.outputs.obr_artifacts_id }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Get last successful workflow run with artifacts for each module
+        id: find-artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./tools/get-last-successful-workflow-run-for-artifacts.sh --repo ${{ github.repository }}
+
+  pr-build-buildutils:
+    name: Build the 'buildutils' module
+    needs: [get-changed-modules, find-artifacts]
+    uses: ./.github/workflows/pr-buildutils.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.buildutils_changed }}
+
+  pr-build-wrapping:
+    name: Build the 'wrapping' module
+    needs: [get-changed-modules, find-artifacts]
+    uses: ./.github/workflows/pr-wrapping.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.wrapping_changed }}
+
+  pr-build-gradle:
+    name: Build the 'gradle' module
+    needs: [get-changed-modules, find-artifacts]
+    uses: ./.github/workflows/pr-gradle.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.gradle_changed }}
+
+  pr-build-maven:
+    name: Build the 'maven' module
+    needs: [get-changed-modules, find-artifacts, pr-build-gradle]
+    uses: ./.github/workflows/pr-maven.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.maven_changed }}
+      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+
+  pr-build-framework:
+    name: Build the 'framework' module
+    needs: [get-changed-modules, find-artifacts, pr-build-buildutils, pr-build-wrapping, pr-build-maven]
+    uses: ./.github/workflows/pr-framework.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.framework_changed }}
+      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
+      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
+
+  pr-build-extensions:
+    name: Build the 'extensions' module
+    needs: [get-changed-modules, find-artifacts, pr-build-framework]
+    uses: ./.github/workflows/pr-extensions.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.extensions_changed }}
+      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
+      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
+      framework-artifact-id: ${{ needs.find-artifacts.outputs.framework_artifacts_id }}
+
+  pr-build-managers:
+    name: Build the 'managers' module
+    needs: [get-changed-modules, find-artifacts, pr-build-framework]
+    uses: ./.github/workflows/pr-managers.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.managers_changed }}
+      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
+      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
+      framework-artifact-id: ${{ needs.find-artifacts.outputs.framework_artifacts_id }}
+
+  pr-build-obr:
+    name: Build the 'obr' module
+    needs: [get-changed-modules, find-artifacts, pr-build-extensions, pr-build-managers]
+    uses: ./.github/workflows/pr-obr.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.obr_changed }}
+      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
+      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
+      framework-artifact-id: ${{ needs.find-artifacts.outputs.framework_artifacts_id }}
+      extensions-artifact-id: ${{ needs.find-artifacts.outputs.extensions_artifacts_id }}
+      managers-artifact-id: ${{ needs.find-artifacts.outputs.managers_artifacts_id }}

--- a/overlays/.github/workflows/pushes.yaml
+++ b/overlays/.github/workflows/pushes.yaml
@@ -142,7 +142,7 @@ jobs:
     uses: ./.github/workflows/obr.yaml
     secrets: inherit
     with:
-      changed: ${{ needs.get-changed-modules.outputs.obr_changed }}
+      changed: ${{ true }} # Always rebuild the OBR as it contains all other modules.
       wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
       gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
       maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}

--- a/overlays/.github/workflows/pushes.yaml
+++ b/overlays/.github/workflows/pushes.yaml
@@ -1,0 +1,151 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Main Build Orchestrator
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+
+  # Get modules that were changed as part of this Push,
+  # set that as an output of this job to be passed to the next job. 
+  get-changed-modules:
+    name: Get the modules changed in this Push
+    runs-on: ubuntu-latest
+
+    outputs:
+      buildutils_changed: ${{ steps.get-changed-modules.outputs.BUILDUTILS_CHANGED }}
+      wrapping_changed: ${{ steps.get-changed-modules.outputs.WRAPPING_CHANGED }}
+      gradle_changed: ${{ steps.get-changed-modules.outputs.GRADLE_CHANGED }}
+      maven_changed: ${{ steps.get-changed-modules.outputs.MAVEN_CHANGED }}
+      framework_changed: ${{ steps.get-changed-modules.outputs.FRAMEWORK_CHANGED }}
+      extensions_changed: ${{ steps.get-changed-modules.outputs.EXTENSIONS_CHANGED }}
+      managers_changed: ${{ steps.get-changed-modules.outputs.MANAGERS_CHANGED }}
+      obr_changed: ${{ steps.get-changed-modules.outputs.OBR_CHANGED }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Log base and head commits of this Push event
+        run : |
+          echo "Base commit: ${{ github.event.before }}"
+          echo "Head commit: ${{ github.sha }}"
+
+      - name: Get the modules changed in this Push
+        id: get-changed-modules
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./tools/get-changed-modules-push.sh --repo ${{ github.repository }} --base ${{ github.event.before }} --head ${{ github.sha }}
+
+  find-artifacts:
+    name: Get Workflow Run IDs with artifacts to download for each module
+    runs-on: ubuntu-latest
+
+    outputs: 
+      buildutils_artifacts_id: ${{ steps.find-artifacts.outputs.buildutils_artifacts_id }}
+      wrapping_artifacts_id: ${{ steps.find-artifacts.outputs.wrapping_artifacts_id }}
+      gradle_artifacts_id: ${{ steps.find-artifacts.outputs.gradle_artifacts_id }}
+      maven_artifacts_id: ${{ steps.find-artifacts.outputs.maven_artifacts_id }}
+      framework_artifacts_id: ${{ steps.find-artifacts.outputs.framework_artifacts_id }}
+      extensions_artifacts_id: ${{ steps.find-artifacts.outputs.extensions_artifacts_id }}
+      managers_artifacts_id: ${{ steps.find-artifacts.outputs.managers_artifacts_id }}
+      obr_artifacts_id: ${{ steps.find-artifacts.outputs.obr_artifacts_id }}
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Get last successful workflow run with artifacts for each module
+        id: find-artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ./tools/get-last-successful-workflow-run-for-artifacts.sh --repo ${{ github.repository }}
+
+  build-buildutils:
+    name: Build the 'buildutils' module
+    needs: [get-changed-modules]
+    uses: ./.github/workflows/buildutils.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.buildutils_changed }}
+
+  build-wrapping:
+    name: Build the 'wrapping' module
+    needs: [get-changed-modules]
+    uses: ./.github/workflows/wrapping.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.wrapping_changed }}
+
+  build-gradle:
+    name: Build the 'gradle' module
+    needs: [get-changed-modules]
+    uses: ./.github/workflows/gradle.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.gradle_changed }}
+
+  build-maven:
+    name: Build the 'maven' module
+    needs: [get-changed-modules, find-artifacts, build-gradle]
+    uses: ./.github/workflows/maven.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.maven_changed }}
+      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+
+  build-framework:
+    name: Build the 'framework' module
+    needs: [get-changed-modules, find-artifacts, build-buildutils, build-wrapping, build-maven]
+    uses: ./.github/workflows/framework.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.framework_changed }}
+      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
+      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
+
+  build-extensions:
+    name: Build the 'extensions' module
+    needs: [get-changed-modules, find-artifacts, build-framework]
+    uses: ./.github/workflows/extensions.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.extensions_changed }}
+      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
+      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
+      framework-artifact-id: ${{ needs.find-artifacts.outputs.framework_artifacts_id }}
+
+  build-managers:
+    name: Build the 'managers' module
+    needs: [get-changed-modules, find-artifacts, build-framework]
+    uses: ./.github/workflows/managers.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.managers_changed }}
+      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
+      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
+      framework-artifact-id: ${{ needs.find-artifacts.outputs.framework_artifacts_id }}
+
+  build-obr:
+    name: Build the 'obr' module
+    needs: [get-changed-modules, find-artifacts, build-extensions, build-managers]
+    uses: ./.github/workflows/obr.yaml
+    secrets: inherit
+    with:
+      changed: ${{ needs.get-changed-modules.outputs.obr_changed }}
+      wrapping-artifact-id: ${{ needs.find-artifacts.outputs.wrapping_artifacts_id }}
+      gradle-artifact-id: ${{ needs.find-artifacts.outputs.gradle_artifacts_id }}
+      maven-artifact-id: ${{ needs.find-artifacts.outputs.maven_artifacts_id }}
+      framework-artifact-id: ${{ needs.find-artifacts.outputs.framework_artifacts_id }}
+      extensions-artifact-id: ${{ needs.find-artifacts.outputs.extensions_artifacts_id }}
+      managers-artifact-id: ${{ needs.find-artifacts.outputs.managers_artifacts_id }}

--- a/overlays/.github/workflows/releases.yaml
+++ b/overlays/.github/workflows/releases.yaml
@@ -1,0 +1,101 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Release Build Orchestrator
+
+on:
+  workflow_dispatch:
+    inputs:
+      jacoco_enabled:
+        description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+        - 'true'
+        - 'false'
+      sign_artifacts:
+        description: 'True if the artifacts built should be signed (set to "false" for development branch builds)'
+        required: true
+        default: 'true'
+        type: choice
+        options:
+        - 'true'
+        - 'false'
+
+jobs:
+
+  build-buildutils:
+    name: Build the 'buildutils' module
+    uses: ./.github/workflows/buildutils.yaml
+    secrets: inherit
+    with:
+      changed: ${{ true }}
+
+  build-wrapping:
+    name: Build the 'wrapping' module
+    uses: ./.github/workflows/wrapping.yaml
+    secrets: inherit
+    with:
+      changed: ${{ true }}
+      jacoco_enabled: ${{ inputs.jacoco_enabled }}
+      sign_artifacts: ${{ inputs.sign_artifacts }}
+
+  build-gradle:
+    name: Build the 'gradle' module
+    uses: ./.github/workflows/gradle.yaml
+    secrets: inherit
+    with:
+      changed: ${{ true }}
+      jacoco_enabled: ${{ inputs.jacoco_enabled }}
+      sign_artifacts: ${{ inputs.sign_artifacts }}
+
+  build-maven:
+    name: Build the 'maven' module
+    needs: [build-gradle]
+    uses: ./.github/workflows/maven.yaml
+    secrets: inherit
+    with:
+      changed: ${{ true }}
+      jacoco_enabled: ${{ inputs.jacoco_enabled }}
+      sign_artifacts: ${{ inputs.sign_artifacts }}
+
+  build-framework:
+    name: Build the 'framework' module
+    needs: [build-buildutils, build-wrapping, build-maven]
+    uses: ./.github/workflows/framework.yaml
+    secrets: inherit
+    with:
+      changed: ${{ true }}
+      jacoco_enabled: ${{ inputs.jacoco_enabled }}
+      sign_artifacts: ${{ inputs.sign_artifacts }}
+
+  build-extensions:
+    name: Build the 'extensions' module
+    needs: [build-framework]
+    uses: ./.github/workflows/extensions.yaml
+    secrets: inherit
+    with:
+      changed: ${{ true }}
+      jacoco_enabled: ${{ inputs.jacoco_enabled }}
+      sign_artifacts: ${{ inputs.sign_artifacts }}
+
+  build-managers:
+    name: Build the 'managers' module
+    needs: [build-framework]
+    uses: ./.github/workflows/managers.yaml
+    secrets: inherit
+    with:
+      changed: ${{ true }}
+      jacoco_enabled: ${{ inputs.jacoco_enabled }}
+      sign_artifacts: ${{ inputs.sign_artifacts }}
+
+  build-obr:
+    name: Build the 'obr' module
+    needs: [build-extensions, build-managers]
+    uses: ./.github/workflows/obr.yaml
+    secrets: inherit
+    with:
+      changed: ${{ true }}

--- a/overlays/.github/workflows/wrapping.yaml
+++ b/overlays/.github/workflows/wrapping.yaml
@@ -63,11 +63,6 @@ jobs:
           java-version: '17'
           distribution: 'semeru'
 
-      # The githash is added to the development Maven registry to show what commit level it contains
-      - name: Print githash
-        run: |
-          echo $GITHUB_SHA > ./wrapping.githash
-
       # Copy secrets into files to use in workflow
       - name: Make secrets directory
         run: |

--- a/overlays/.github/workflows/wrapping.yaml
+++ b/overlays/.github/workflows/wrapping.yaml
@@ -1,0 +1,146 @@
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Wrapping Main Build
+
+on:
+  workflow_call:
+    inputs:
+      changed:
+        description: 'True if this module has been changed and should be rebuilt'
+        required: true
+        type: string
+      jacoco_enabled:
+        description: 'True if Jacoco code coverage should be enabled (set to "false" for release builds)'
+        required: false
+        default: 'true'
+        type: string
+      sign_artifacts:
+        description: 'True if the artifacts built should be signed (set to "false" for development branch builds)'
+        required: false
+        default: 'true'
+        type: string
+
+env:
+  BRANCH: ${{ github.ref_name }}
+
+jobs:
+
+  log-unchanged:
+    name: Wrapping is unchanged
+    if: ${{ inputs.changed == 'false' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Log this module is unchanged
+        run: |
+          echo "The wrapping module is unchanged"
+
+  log-github-ref:
+    name: Log the GitHub ref this workflow is running on (Branch or tag that received dispatch)
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Log GitHub ref of workflow
+        run: |
+          echo "This workflow is running on GitHub ref ${{ env.BRANCH }}"
+
+  build-wrapping:
+    name: Build Wrapping source code and Docker image for development Maven registry
+    if: ${{ inputs.changed == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'semeru'
+
+      # The githash is added to the development Maven registry to show what commit level it contains
+      - name: Print githash
+        run: |
+          echo $GITHUB_SHA > ./wrapping.githash
+
+      # Copy secrets into files to use in workflow
+      - name: Make secrets directory
+        run: |
+          mkdir /home/runner/work/secrets
+      - name: Copy settings.xml
+        env:
+          MAVEN_SETTINGS_XML: ${{ secrets.MAVEN_SETTINGS_XML }}
+        run: |
+          echo $MAVEN_SETTINGS_XML > /home/runner/work/secrets/settings.xml
+      - name: Copy GPG passphrase
+        env:
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          echo $GPG_PASSPHRASE > /home/runner/work/secrets/passphrase.file
+      - name: Copy GPG key
+        env:
+          GPG_KEY_BASE64: ${{ secrets.GPG_KEY }}
+        run: |
+          echo $GPG_KEY_BASE64 |  base64 --decode > /home/runner/work/secrets/galasa.gpg
+          
+      # Set up Maven GPG directory
+      - name: Make GPG home directory
+        run: |
+          mkdir /home/runner/work/gpg
+      
+      - name: Change directory permissions
+        run: |
+          chmod '700' /home/runner/work/gpg
+
+      - name: Import GPG
+        run: |
+          gpg --homedir /home/runner/work/gpg --pinentry-mode loopback --passphrase-file /home/runner/work/secrets/passphrase.file --import /home/runner/work/secrets/galasa.gpg
+      
+      - name: Copy custom settings.xml
+        run: |
+          cp /home/runner/work/secrets/settings.xml /home/runner/work/gpg/settings.xml
+
+      - name: Build Wrapping source code
+        working-directory: modules/wrapping
+        run : |
+          set -o pipefail
+          mvn deploy -X \
+          -Dgalasa.source.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.central.repo=https://repo.maven.apache.org/maven2/ \
+          -Dgalasa.release.repo=file:${{ github.workspace }}/modules/wrapping/repo \
+          -Dgalasa.jacocoEnabled=${{ inputs.jacoco_enabled }} \
+          -Dgalasa.isRelease=${{ inputs.sign_artifacts }} \
+          --batch-mode --errors --fail-at-end \
+          --settings /home/runner/work/gpg/settings.xml 2>&1 | tee build.log
+
+      - name: Upload Maven Build Log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wrapping-maven-build-log
+          path: modules/wrapping/build.log
+
+      - name: Upload wrapping artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wrapping
+          path: modules/wrapping/repo/dev/galasa
+          retention-days: 7
+
+  # report-failure:
+  #   name: Report failure in workflow
+  #   runs-on: ubuntu-latest
+  #   needs: [log-github-ref, build-wrapping]
+  #   if: failure()
+
+  #   steps:
+  #     - name: Report failure in workflow to Slack
+  #       env: 
+  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+  #       run : |
+  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "wrapping" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/wrapping.yaml
+++ b/overlays/.github/workflows/wrapping.yaml
@@ -132,15 +132,15 @@ jobs:
           path: modules/wrapping/repo/dev/galasa
           retention-days: 7
 
-  # report-failure:
-  #   name: Report failure in workflow
-  #   runs-on: ubuntu-latest
-  #   needs: [log-github-ref, build-wrapping]
-  #   if: failure()
+  report-failure:
+    name: Report failure in workflow
+    runs-on: ubuntu-latest
+    needs: [log-github-ref, build-wrapping]
+    if: failure()
 
-  #   steps:
-  #     - name: Report failure in workflow to Slack
-  #       env: 
-  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-  #       run : |
-  #         docker run --rm -v ${{ github.workspace }}:/var/workspace ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "wrapping" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"
+    steps:
+      - name: Report failure in workflow to Slack
+        env: 
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run : |
+          docker run --rm ghcr.io/galasa-dev/galasabld-ibm:main slackpost workflows --repo "wrapping" --workflowName "${{ github.workflow }}" --workflowRunNum "${{ github.run_id }}" --ref "${{ env.BRANCH }}" --hook "${{ env.SLACK_WEBHOOK }}"

--- a/overlays/.github/workflows/wrapping.yaml
+++ b/overlays/.github/workflows/wrapping.yaml
@@ -124,7 +124,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wrapping
-          path: modules/wrapping/repo/dev/galasa
+          path: modules/wrapping/repo
           retention-days: 7
 
   report-failure:

--- a/overlays/tools/build-locally.sh
+++ b/overlays/tools/build-locally.sh
@@ -89,7 +89,6 @@ module_names=(\
     "extensions" \
     "managers" \
     "obr" \
-    "cli" \
 )
 
 function check_module_name_is_supported() {
@@ -246,17 +245,6 @@ function build_module() {
         h2 "Building $module"
         cd ${PROJECT_DIR}/modules/$module
         ${PROJECT_DIR}/modules/$module/build-locally.sh
-        rc=$? ;  if [[ "${rc}" != "0" ]]; then error "Failed to build module $module. rc=$rc" ; exit 1 ; fi
-        success "Built module $module OK"
-        if [[ "$chain" == "true" ]]; then 
-            module="cli"
-        fi
-    fi
-
-    # cli
-    if [[ "$module" == "cli" ]]; then
-        cd ${PROJECT_DIR}/modules/$module
-        ${PROJECT_DIR}/modules/$module/build-locally.sh --clean
         rc=$? ;  if [[ "${rc}" != "0" ]]; then error "Failed to build module $module. rc=$rc" ; exit 1 ; fi
         success "Built module $module OK"
     fi

--- a/overlays/tools/get-changed-modules-pull-request.sh
+++ b/overlays/tools/get-changed-modules-pull-request.sh
@@ -105,7 +105,7 @@ function get_paths_changed_in_pr() {
     h1 "Getting the file paths changed in Pull Request number ${pr_number}" 
 
     # Extract changed module names from changed files from GitHub CLI output
-    mapfile -t changed_files_in_pr < <(gh pr diff --repo jadecarino/galasa ${pr_number} --name-only)
+    mapfile -t changed_files_in_pr < <(gh pr diff --repo galasa-dev/galasa ${pr_number} --name-only)
 
     h2 "Files changed:"
 

--- a/overlays/tools/get-changed-modules-pull-request.sh
+++ b/overlays/tools/get-changed-modules-pull-request.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Objectives: Get all modules that have been changed in a Pull Request.
+# 
+#-----------------------------------------------------------------------------------------                   
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+# echo "Running from directory ${BASEDIR}"
+export ORIGINAL_DIR=$(pwd)
+# cd "${BASEDIR}"
+
+cd "${BASEDIR}/.."
+PROJECT_DIR=$(pwd)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Set Colors
+#
+#-----------------------------------------------------------------------------------------                   
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Headers and Logging
+#
+#-----------------------------------------------------------------------------------------                   
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ; }
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ; }
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ; }
+debug() { printf "${white}[.] %s${reset}\n" "$@" ; }
+info()  { printf "${white}[➜] %s${reset}\n" "$@" ; }
+success() { printf "${white}[${green}✔${white}] ${green}%s${reset}\n" "$@" ; }
+error() { printf "${white}[${red}✖${white}] ${red}%s${reset}\n" "$@" ; }
+warn() { printf "${white}[${tan}➜${white}] ${tan}%s${reset}\n" "$@" ; }
+bold() { printf "${bold}%s${reset}\n" "$@" ; }
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ; }
+
+#-----------------------------------------------------------------------------------------                   
+# Functions
+#-----------------------------------------------------------------------------------------                   
+function usage {
+    info "Syntax: get-changed-modules-pull-request.sh [OPTIONS]"
+    cat << EOF
+Options are:
+-h | --help : Display this help text
+--pr-number The number of the Pull Request
+EOF
+}
+
+module_names=(\
+    "buildutils" \
+    "wrapping" \
+    "gradle" \
+    "maven" \
+    "framework" \
+    "extensions" \
+    "managers" \
+    "obr" \
+)
+
+#-----------------------------------------------------------------------------------------                   
+# Process parameters
+#-----------------------------------------------------------------------------------------
+pr_number=""
+while [ "$1" != "" ]; do
+    case $1 in
+        -h | --help )       usage
+                            exit
+                            ;;
+
+        --pr-number )       pr_number="$2"
+                            shift
+                            ;;
+
+        * )                 error "Unexpected argument $1"
+                            usage
+                            exit 1
+    esac
+    shift
+done
+
+#-----------------------------------------------------------------------------------------                   
+# Functions
+#-----------------------------------------------------------------------------------------  
+
+function get_paths_changed_in_pr() {
+
+    h1 "Getting the file paths changed in Pull Request number ${pr_number}" 
+
+    # Extract changed module names from changed files from GitHub CLI output
+    mapfile -t changed_files_in_pr < <(gh pr diff --repo jadecarino/galasa ${pr_number} --name-only)
+
+    h2 "Files changed:"
+
+    modules_changed_in_pr=()
+    for changed_file in "${changed_files_in_pr[@]}"; do
+        echo "$changed_file"
+        module=$(echo "$changed_file" | cut -d'/' -f2)
+        modules_changed_in_pr+=("$module")
+    done
+
+    # Remove possible duplicates from array of changed modules
+    declare -A unique_module_map
+
+    unique_modules_found_in_pr=()
+    for module in "${modules_changed_in_pr[@]}"; do
+    if [[ -z "${unique_module_map[$module]}" ]]; then
+        unique_modules_found_in_pr+=("$module")
+        unique_module_map[$module]=1
+    fi
+    done
+
+    h2 "Modules changed:"
+    echo "${unique_modules_found_in_pr[@]}"
+}
+
+function get_changed_modules_and_set_in_environment() {
+
+    h1 "Finding changed modules and setting environment variables that can be used in the GitHub Actions workflows..."
+
+    for module in "${unique_modules_found_in_pr[@]}"; do
+        if [[ "$module" == "buildutils" ]]; then
+            echo "BUILDUTILS_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "wrapping" ]]; then
+            echo "WRAPPING_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "gradle" ]]; then
+            echo "GRADLE_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "maven" ]]; then
+            echo "MAVEN_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "framework" ]]; then
+            echo "FRAMEWORK_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "extensions" ]]; then
+            echo "EXTENSIONS_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "managers" ]]; then
+            echo "MANAGERS_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "obr" ]]; then
+            echo "OBR_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+    done
+}
+
+# Set outputs to false as default value.
+echo "BUILDUTILS_CHANGED=false" >> $GITHUB_OUTPUT
+echo "WRAPPING_CHANGED=false" >> $GITHUB_OUTPUT
+echo "GRADLE_CHANGED=false" >> $GITHUB_OUTPUT
+echo "MAVEN_CHANGED=false" >> $GITHUB_OUTPUT
+echo "FRAMEWORK_CHANGED=false" >> $GITHUB_OUTPUT
+echo "EXTENSIONS_CHANGED=false" >> $GITHUB_OUTPUT
+echo "MANAGERS_CHANGED=false" >> $GITHUB_OUTPUT
+echo "OBR_CHANGED=false" >> $GITHUB_OUTPUT
+
+get_paths_changed_in_pr
+get_changed_modules_and_set_in_environment

--- a/overlays/tools/get-changed-modules-push.sh
+++ b/overlays/tools/get-changed-modules-push.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Objectives: Get all modules that have been changed in a Push (Merge of a Pull Request).
+# 
+#-----------------------------------------------------------------------------------------                   
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+# echo "Running from directory ${BASEDIR}"
+export ORIGINAL_DIR=$(pwd)
+# cd "${BASEDIR}"
+
+cd "${BASEDIR}/.."
+PROJECT_DIR=$(pwd)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Set Colors
+#
+#-----------------------------------------------------------------------------------------                   
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Headers and Logging
+#
+#-----------------------------------------------------------------------------------------                   
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ; }
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ; }
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ; }
+debug() { printf "${white}[.] %s${reset}\n" "$@" ; }
+info()  { printf "${white}[➜] %s${reset}\n" "$@" ; }
+success() { printf "${white}[${green}✔${white}] ${green}%s${reset}\n" "$@" ; }
+error() { printf "${white}[${red}✖${white}] ${red}%s${reset}\n" "$@" ; }
+warn() { printf "${white}[${tan}➜${white}] ${tan}%s${reset}\n" "$@" ; }
+bold() { printf "${bold}%s${reset}\n" "$@" ; }
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ; }
+
+#-----------------------------------------------------------------------------------------                   
+# Functions
+#-----------------------------------------------------------------------------------------                   
+function usage {
+    info "Syntax: get-changed-modules-push.sh [OPTIONS]"
+    cat << EOF
+Options are:
+-h | --help : Display this help text
+--repo The repository for this GitHub Actions workflow
+--base The base commit level (the commit before the push)
+--head The head commit level (the commit that triggered the push)
+EOF
+}
+
+module_names=(\
+    "buildutils" \
+    "wrapping" \
+    "gradle" \
+    "maven" \
+    "framework" \
+    "extensions" \
+    "managers" \
+    "obr" \
+)
+
+#-----------------------------------------------------------------------------------------
+# Process parameters
+#-----------------------------------------------------------------------------------------
+repo=""
+base=""
+head=""
+while [ "$1" != "" ]; do
+    case $1 in
+        -h | --help )   usage
+                        exit
+                        ;;
+
+        --repo )        repo="$2"
+                        shift
+                        ;;
+
+        --base )        base="$2"
+                        shift
+                        ;;
+
+        --head )        head="$2"
+                        shift
+                        ;;
+
+        * )             error "Unexpected argument $1"
+                        usage
+                        exit 1
+    esac
+    shift
+done
+
+#-----------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------
+
+function get_files_changed_in_push() {
+
+    h1 "Getting the files changed in Push event triggered by commit ${head}" 
+
+    h2 "Files changed:"
+    gh api repos/${repo}/compare/${base}...${head} --jq '.files[].filename'
+
+    # Extract changed module names from changed files from GitHub CLI output
+    mapfile -t changed_files_in_push < <(gh api repos/${repo}/compare/${base}...${head} --jq '.files[].filename')
+
+    modules_changed_in_push=()
+    for changed_file in "${changed_files_in_push[@]}"; do
+        echo "$changed_file"
+        module=$(echo "$changed_file" | cut -d'/' -f2)
+        modules_changed_in_push+=("$module")
+    done
+
+    # Remove possible duplicates from array of changed modules
+    declare -A unique_module_map
+
+    unique_modules_found_in_push=()
+    for module in "${modules_changed_in_push[@]}"; do
+    if [[ -z "${unique_module_map[$module]}" ]]; then
+        unique_modules_found_in_push+=("$module")
+        unique_module_map[$module]=1
+    fi
+    done
+
+    h2 "Modules changed:"
+    echo "${unique_modules_found_in_push[@]}"
+
+}
+
+function get_changed_modules_and_set_in_environment() {
+
+    h1 "Finding changed modules and setting environment variables that can be used in the GitHub Actions workflows..."
+
+    for module in "${unique_modules_found_in_push[@]}"; do
+        if [[ "$module" == "buildutils" ]]; then
+            echo "BUILDUTILS_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "wrapping" ]]; then
+            echo "WRAPPING_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "gradle" ]]; then
+            echo "GRADLE_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "maven" ]]; then
+            echo "MAVEN_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "framework" ]]; then
+            echo "FRAMEWORK_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "extensions" ]]; then
+            echo "EXTENSIONS_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "managers" ]]; then
+            echo "MANAGERS_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+        if [[ "$module" == "obr" ]]; then
+            echo "OBR_CHANGED=true" >> $GITHUB_OUTPUT
+            continue
+        fi
+    done
+}
+
+# Set outputs to false as default value.
+echo "BUILDUTILS_CHANGED=false" >> $GITHUB_OUTPUT
+echo "WRAPPING_CHANGED=false" >> $GITHUB_OUTPUT
+echo "GRADLE_CHANGED=false" >> $GITHUB_OUTPUT
+echo "MAVEN_CHANGED=false" >> $GITHUB_OUTPUT
+echo "FRAMEWORK_CHANGED=false" >> $GITHUB_OUTPUT
+echo "EXTENSIONS_CHANGED=false" >> $GITHUB_OUTPUT
+echo "MANAGERS_CHANGED=false" >> $GITHUB_OUTPUT
+echo "OBR_CHANGED=false" >> $GITHUB_OUTPUT
+
+get_files_changed_in_push
+get_changed_modules_and_set_in_environment

--- a/overlays/tools/get-last-successful-workflow-run-for-artifacts.sh
+++ b/overlays/tools/get-last-successful-workflow-run-for-artifacts.sh
@@ -119,7 +119,8 @@ function get_last_successful_workflow_id() {
 
 }
 
-get_last_successful_workflow_id buildutils "Buildutils is unchanged"
+get_last_successful_workflow_id openapi2beans "Buildutils is unchanged"
+get_last_successful_workflow_id galasabld "Buildutils is unchanged"
 get_last_successful_workflow_id wrapping "Wrapping is unchanged"
 get_last_successful_workflow_id gradle "Gradle is unchanged"
 get_last_successful_workflow_id maven "Maven is unchanged"

--- a/overlays/tools/get-last-successful-workflow-run-for-artifacts.sh
+++ b/overlays/tools/get-last-successful-workflow-run-for-artifacts.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+
+#
+# Copyright contributors to the Galasa project
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Objectives: Get the last successful workflow run ID to get artifacts from if the current
+#             workflow run has not built a particular module.
+# 
+#-----------------------------------------------------------------------------------------                   
+
+# Where is this script executing from ?
+BASEDIR=$(dirname "$0");pushd $BASEDIR 2>&1 >> /dev/null ;BASEDIR=$(pwd);popd 2>&1 >> /dev/null
+# echo "Running from directory ${BASEDIR}"
+export ORIGINAL_DIR=$(pwd)
+# cd "${BASEDIR}"
+
+cd "${BASEDIR}/.."
+PROJECT_DIR=$(pwd)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Set Colors
+#
+#-----------------------------------------------------------------------------------------                   
+bold=$(tput bold)
+underline=$(tput sgr 0 1)
+reset=$(tput sgr0)
+red=$(tput setaf 1)
+green=$(tput setaf 76)
+white=$(tput setaf 7)
+tan=$(tput setaf 202)
+blue=$(tput setaf 25)
+
+#-----------------------------------------------------------------------------------------                   
+#
+# Headers and Logging
+#
+#-----------------------------------------------------------------------------------------                   
+underline() { printf "${underline}${bold}%s${reset}\n" "$@" ; }
+h1() { printf "\n${underline}${bold}${blue}%s${reset}\n" "$@" ; }
+h2() { printf "\n${underline}${bold}${white}%s${reset}\n" "$@" ; }
+debug() { printf "${white}[.] %s${reset}\n" "$@" ; }
+info()  { printf "${white}[➜] %s${reset}\n" "$@" ; }
+success() { printf "${white}[${green}✔${white}] ${green}%s${reset}\n" "$@" ; }
+error() { printf "${white}[${red}✖${white}] ${red}%s${reset}\n" "$@" ; }
+warn() { printf "${white}[${tan}➜${white}] ${tan}%s${reset}\n" "$@" ; }
+bold() { printf "${bold}%s${reset}\n" "$@" ; }
+note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" "$@" ; }
+
+#-----------------------------------------------------------------------------------------                   
+# Functions
+#-----------------------------------------------------------------------------------------                   
+function usage {
+    info "Syntax: get-last-successful-workflow-run-for-artifacts.sh [OPTIONS]"
+    cat << EOF
+Options are:
+-h | --help : Display this help text
+--repo          The repository for this GitHub Actions workflow
+EOF
+}
+
+#-----------------------------------------------------------------------------------------
+# Process parameters
+#-----------------------------------------------------------------------------------------
+repo=""
+while [ "$1" != "" ]; do
+    case $1 in
+        -h | --help )       usage
+                            exit
+                            ;;
+
+        --repo )            repo="$2"
+                            shift
+                            ;;
+
+        * )                 error "Unexpected argument $1"
+                            usage
+                            exit 1
+    esac
+    shift
+done
+
+#-----------------------------------------------------------------------------------------
+# Functions
+#-----------------------------------------------------------------------------------------
+
+function get_last_successful_workflow_id() {
+
+    MODULE=$1
+    SKIPPED_JOB_NAME=$2
+
+    h1 "Getting the last successful workflow run ID that has stored artifacts for the ${MODULE} module" 
+
+    h2 "Using the GitHub CLI to list the successful runs of the Main Build Orchestrator workflow"
+    gh run list --repo "${repo}" --workflow "Main Build Orchestrator" --status success | tee gh-run-list.log
+
+    h2 "Extracting the run IDs from the output"
+    output=$(cat gh-run-list.log 2>&1)
+    run_ids=($(echo "$output" | grep -oE '[0-9]{11}'))
+
+    echo "Extracted IDs: ${run_ids[@]}"
+
+    for run_id in "${run_ids[@]}"; do
+        echo "Checking if the run ${run_id} ran the ${MODULE} build or skipped it"
+        if gh run view ${run_id} --log 2>&1 | grep -q "${SKIPPED_JOB_NAME}"; then
+            echo "The build of module ${MODULE} was skipped so will have no artifacts in this workflow run."
+        else
+            echo "The build of module ${MODULE} was not skipped - artifacts should be available to download!"
+            echo "${MODULE}_artifacts_id=${run_id}" >> $GITHUB_OUTPUT
+            break
+        fi
+    done
+
+}
+
+get_last_successful_workflow_id buildutils "Buildutils is unchanged"
+get_last_successful_workflow_id wrapping "Wrapping is unchanged"
+get_last_successful_workflow_id gradle "Gradle is unchanged"
+get_last_successful_workflow_id maven "Maven is unchanged"
+get_last_successful_workflow_id framework "Framework is unchanged"
+get_last_successful_workflow_id extensions "Extensions is unchanged"
+get_last_successful_workflow_id managers "Managers is unchanged"
+get_last_successful_workflow_id obr "OBR is unchanged"

--- a/tools/generate-mono-repo.sh
+++ b/tools/generate-mono-repo.sh
@@ -173,6 +173,7 @@ function push_repo_to_github() {
     h2 "Pushing the 'galasa' repo to github.com"
     cd $GALASA_DIR
     gh repo new \
+    $GIT_ORG/galasa \
     --description "The Galasa source code" \
     --public \
     --push \

--- a/tools/generate-mono-repo.sh
+++ b/tools/generate-mono-repo.sh
@@ -61,7 +61,7 @@ note() { printf "\n${underline}${bold}${blue}Note:${reset} ${blue}%s${reset}\n" 
 #
 # Tailor these to suit your environment
 #-------------------------------------------------------------------------- 
-export GIT_ORG="techcobweb"
+export GIT_ORG="galasa-dev"
 
 function delete_local_galasa_repo() {
     h2 "Deleting the $GALASA_DIR repo"
@@ -104,6 +104,13 @@ function copy_overlays_into_mono_repo() {
     $cmd
     rc=$? ; if [[ "$rc" != "0" ]]; then error "Failed to copy 'overlays' into the 'galasa' folder" ; exit 1 ; fi
     success "Copied overlays over the top of the original repo contents."
+
+    h2 "Copying hidden folders from 'overlays' into the 'galasa' project"
+    cmd="cp -R $PROJECT_DIR/overlays/. $GALASA_DIR"
+    info "Command is $cmd"
+    $cmd
+    rc=$? ; if [[ "$rc" != "0" ]]; then error "Failed to copy hidden folders from 'overlays' into the 'galasa' folder" ; exit 1 ; fi
+    success "Copied hidden folders from overlays over the top of the original repo contents."
 
     git add .
     rc=$? ; if [[ "$rc" != "0" ]]; then error "Failed to add 'overlays' into the 'galasa' repo staging area" ; exit 1 ; fi
@@ -194,7 +201,6 @@ merge_in_repo framework
 merge_in_repo extensions
 merge_in_repo managers
 merge_in_repo obr
-merge_in_repo cli
 
 copy_overlays_into_mono_repo
 


### PR DESCRIPTION
## Why?

For https://github.com/galasa-dev/projectmanagement/issues/1828

GitHub workflows added into the overlays folder so they are added into the mono repo on top of the modules.
Adjustments made to script to ensure hidden folder `.github` is copied over into the overlays.
Removed CLI from the script as we are not adding it into the mono repo yet.